### PR TITLE
openapi: fix how geometry are handled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,157 @@
+stages:
+
+  - 🐍 lint
+  - 🤞 test
+  - 📦 build
+  - 🚀 deploy
+
+variables:
+  PROJECT_FOLDER: "pg_featureserv"
+  REPO_PLUGIN_URL: "https://git.oslandia.net/Client-projects/geoplateforme-ign-pg-featureserv"
+  SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar" # Defines the location of the analysis task cache
+  POSTGRES_VERSION: "13"
+  POSTGIS_VERSION: "3.2"
+  GO_VERSION: "1.19"
+
+
+# ======================================================================================
+# -- CONTAINERS JOBS -------------------------------------------------------------------
+# ======================================================================================
+
+
+
+# ======================================================================================
+# -- LINT JOBS -------------------------------------------------------------------------
+# ======================================================================================
+
+include:
+  - template: Code-Quality.gitlab-ci.yml
+  - template: Security/SAST.gitlab-ci.yml
+
+sast:
+  tags:
+    - docker
+  stage: 🐍 lint
+
+code_quality:
+  tags:
+    - linux_vm
+  stage: 🐍 lint
+
+go-linter:
+  tags:
+    - docker
+  stage: 🐍 lint
+  image: "golang:1.18"
+  only:
+    refs:
+      - merge_requests
+      - main
+      - develop
+    changes:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".gitlab-ci.yml"
+  before_script:
+    - apt-get update && apt-get install -y pre-commit curl
+    - pre-commit install --install-hooks
+    - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+  script:
+    - pre-commit run -a -v
+
+
+
+# ======================================================================================
+# -- TEST JOBS -------------------------------------------------------------------------
+# ======================================================================================
+
+# -- GO TEST
+go-test-unit:
+  tags:
+    - docker
+  stage: 🤞 test
+  variables:
+      POSTGRES_DB: pg_featureserv
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgis/${POSTGRES_DB}"
+  parallel:
+    matrix:
+      - GO_VERSION: "1.13"
+      - GO_VERSION: "1.16"
+      - GO_VERSION: "1.18"
+      - GO_VERSION: "1.19"
+  image: "golang:${GO_VERSION}"
+  services:
+    - name: postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION}-alpine
+      alias: postgis
+  only:
+    refs:
+      - merge_requests
+      - main
+      - develop
+    changes:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".gitlab-ci.yml"
+
+  before_script:
+    - go get github.com/boumenot/gocover-cobertura
+    - go install github.com/boumenot/gocover-cobertura
+
+  script:
+    # run test:
+    - |
+       go test $(go list ./... | grep -v /vendor/) -v \
+       -coverprofile=coverage.txt \
+       -covermode count \
+       -coverpkg $(go list ./... | grep -v vendor | grep -v test | xargs | sed 's/ /,/g')
+    # generate report:
+    - go run github.com/boumenot/gocover-cobertura < coverage.txt > coverage-unit_${GO_VERSION}.xml
+    # compute valid coverage total:
+    - go tool cover -func=coverage.txt
+
+  artifacts:
+    reports:
+      cobertura: coverage-unit_${GO_VERSION}.xml
+
+
+# ======================================================================================
+# -- BUILD JOBS -------------------------------------------------------------------------
+# ======================================================================================
+
+# -- HUGO DOCUMENTATION
+build-hugo-doc:
+  tags:
+    - docker
+  stage: 📦 build
+  image: "golang:${GO_VERSION}"
+
+  only:
+    refs:
+      - merge_requests
+      - main
+      - develop
+    changes:
+      - "**/*.md"
+      - ".gitlab-ci.yml"
+
+  before_script:
+    - git submodule update --init hugo/themes/crunchy-hugo-theme
+    - go get github.com/gohugoio/hugo
+    - go install github.com/gohugoio/hugo
+
+  script:
+   # retrieve pg_featureserv version from go code
+   - APP_VERSION=$(grep 'var setVersion string = ' internal/conf/appconfig.go| cut -d '"' -f 2)
+   # update documentation version
+   - echo "number = \"${APP_VERSION}\"" > hugo/data/version.toml
+   - make docs
+
+  artifacts:
+    name: "pg_featureserv-documentation-${APP_VERSION}"
+    expose_as: "pg_featureserv-documentation-latest"
+    paths:
+      - docs/

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9
+	github.com/boumenot/gocover-cobertura v1.2.0 // indirect
 	github.com/getkin/kin-openapi v0.2.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9/go.m
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/boumenot/gocover-cobertura v1.2.0 h1:g+VROIASoEHBrEilIyaCmgo7HGm+AV5yKEPLk0qIY+s=
+github.com/boumenot/gocover-cobertura v1.2.0/go.mod h1:fz7ly8dslE42VRR5ZWLt2OHGDHjkTiA2oNvKgJEjLT0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
@@ -187,6 +189,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/theckman/httpforwarded v0.4.0 h1:N55vGJT+6ojTnLY3LQCNliJC4TW0P0Pkeys1G1WpX2w=
@@ -260,7 +264,9 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200526224456-8b020aee10d2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -288,4 +294,5 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -165,18 +165,13 @@ var FeatureSchema openapi3.Schema = openapi3.Schema{
 		},
 		"geometry": {
 			Value: &openapi3.Schema{
-				Items: &openapi3.SchemaRef{
-					Value: &openapi3.Schema{
-						Type: "string", // mandatory to validate the schema
-						OneOf: []*openapi3.SchemaRef{
-							openapi3.NewSchemaRef("https://geojson.org/schema/Point.json", &openapi3.Schema{Type: "string"}),
-							openapi3.NewSchemaRef("https://geojson.org/schema/LineString.json", &openapi3.Schema{Type: "string"}),
-							openapi3.NewSchemaRef("https://geojson.org/schema/Polygon.json", &openapi3.Schema{Type: "string"}),
-							openapi3.NewSchemaRef("https://geojson.org/schema/MultiPoint.json", &openapi3.Schema{Type: "string"}),
-							openapi3.NewSchemaRef("https://geojson.org/schema/MultiLineString.json", &openapi3.Schema{Type: "string"}),
-							openapi3.NewSchemaRef("https://geojson.org/schema/MultiPolygon.json", &openapi3.Schema{Type: "string"}),
-						},
-					},
+				OneOf: []*openapi3.SchemaRef{
+					openapi3.NewSchemaRef("https://geojson.org/schema/Point.json", &openapi3.Schema{}),
+					openapi3.NewSchemaRef("https://geojson.org/schema/LineString.json", &openapi3.Schema{}),
+					openapi3.NewSchemaRef("https://geojson.org/schema/Polygon.json", &openapi3.Schema{}),
+					openapi3.NewSchemaRef("https://geojson.org/schema/MultiPoint.json", &openapi3.Schema{}),
+					openapi3.NewSchemaRef("https://geojson.org/schema/MultiLineString.json", &openapi3.Schema{}),
+					openapi3.NewSchemaRef("https://geojson.org/schema/MultiPolygon.json", &openapi3.Schema{}),
 				},
 			},
 		},

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -466,16 +466,7 @@ func getCreateItemSchema(ctx context.Context, table *api.Table) (openapi3.Schema
 					Default: "Feature",
 				},
 			},
-			"geometry": {
-				Value: &openapi3.Schema{
-					Items: &openapi3.SchemaRef{
-						Ref: fmt.Sprintf("https://geojson.org/schema/%v.json", table.GeometryType),
-						Value: &openapi3.Schema{
-							Type: "string", // mandatory to validate the schema
-						},
-					},
-				},
-			},
+			"geometry": openapi3.NewSchemaRef(fmt.Sprintf("https://geojson.org/schema/%v.json", table.GeometryType), &openapi3.Schema{}),
 			"properties": {
 				Value: &openapi3.Schema{},
 			},
@@ -535,16 +526,7 @@ func getUpdateItemSchema(ctx context.Context, table *api.Table) (openapi3.Schema
 					Default: "Feature",
 				},
 			},
-			"geometry": {
-				Value: &openapi3.Schema{
-					Items: &openapi3.SchemaRef{
-						Ref: fmt.Sprintf("https://geojson.org/schema/%v.json", table.GeometryType),
-						Value: &openapi3.Schema{
-							Type: "string", // mandatory to validate the schema
-						},
-					},
-				},
-			},
+			"geometry": openapi3.NewSchemaRef(fmt.Sprintf("https://geojson.org/schema/%v.json", table.GeometryType), &openapi3.Schema{}),
 			"properties": {
 				Value: &openapi3.Schema{},
 			},
@@ -693,15 +675,15 @@ func handlePartialUpdateItem(w http.ResponseWriter, r *http.Request) *appError {
 	}
 
 	// check schema
-	var val map[string]interface{}
-	errUnMarsh := json.Unmarshal(body, &val)
-	if errUnMarsh != nil {
-		return appErrorInternalFmt(errUnMarsh, "Json not conform")
+	updateSchema, errGetSch := getUpdateItemSchema(r.Context(), tbl)
+	if errGetSch != nil {
+		return appErrorInternalFmt(errGetSch, errGetSch.Error())
 	}
-
-	errSchema := api.FeatureSchema.VisitJSONObject(val)
-	if errSchema != nil {
-		return appErrorInternalFmt(errSchema, "Data not respect schema: %v", name)
+	var val map[string]interface{}
+	_ = json.Unmarshal(body, &val)
+	errValSch := updateSchema.VisitJSON(val)
+	if errValSch != nil {
+		return appErrorInternalFmt(errValSch, api.ErrMsgCreateFeatureNotConform, name)
 	}
 
 	check, errChck := tbl.CheckTableFields(val)

--- a/internal/service/handler_post_test.go
+++ b/internal/service/handler_post_test.go
@@ -78,7 +78,7 @@ func TestGetCollectionCreateSchema(t *testing.T) {
 	util.Assert(t, errUnMarsh == nil, fmt.Sprintf("%v", errUnMarsh))
 
 	util.Equals(t, "This dataset contains mock data about A (9 points)", fis.Description, "feature description")
-	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Value.Items.Ref, "feature geometry")
+	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Ref, "feature geometry")
 	util.Equals(t, "prop_a", fis.Properties["properties"].Value.Required[0], "feature required a")
 	util.Equals(t, "prop_b", fis.Properties["properties"].Value.Required[1], "feature required b")
 	util.Equals(t, "Feature", fis.Properties["type"].Value.Default, "feature required b")

--- a/internal/service/handler_put_test.go
+++ b/internal/service/handler_put_test.go
@@ -56,7 +56,7 @@ func TestGetCollectionReplaceSchema(t *testing.T) {
 	util.Assert(t, errUnMarsh == nil, fmt.Sprintf("%v", errUnMarsh))
 
 	util.Equals(t, "This dataset contains mock data about A (9 points)", fis.Description, "feature description")
-	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Value.Items.Ref, "feature geometry")
+	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Ref, "feature geometry")
 	util.Equals(t, "prop_a", fis.Properties["properties"].Value.Required[0], "feature required a")
 	util.Equals(t, "prop_b", fis.Properties["properties"].Value.Required[1], "feature required b")
 	util.Equals(t, "Feature", fis.Properties["type"].Value.Default, "feature required b")

--- a/internal/service/handler_update_test.go
+++ b/internal/service/handler_update_test.go
@@ -54,7 +54,7 @@ func TestGetCollectionUpdateSchema(t *testing.T) {
 	util.Assert(t, errUnMarsh == nil, fmt.Sprintf("%v", errUnMarsh))
 
 	util.Equals(t, "This dataset contains mock data about A (9 points)", fis.Description, "feature description")
-	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Value.Items.Ref, "feature geometry")
+	util.Equals(t, "https://geojson.org/schema/Point.json", fis.Properties["geometry"].Ref, "feature geometry")
 	util.Equals(t, 0, len(fis.Required), "no required field")
 	util.Equals(t, 2, len(fis.Properties["properties"].Value.Properties["prop_a"].Value.OneOf), "properties have 2 possible values, one is nil")
 }


### PR DESCRIPTION
In GitLab by @benoitdm-oslandia on Oct 12, 2022, 14:58

openapi definition for geojson geometries was malformed and not correctly parsed,
f.e. empty geomtry object were validated. This fix also simplifies the openapi readability.

ref !29

closes #63