### PR TITLE
Feat/if none match

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9
 	github.com/getkin/kin-openapi v0.104.0
+	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/getkin/kin-openapi v0.104.0 h1:DZ2F89M/nnjgmIq08Fr/rxmtHmC9A0RVqFWr/ZPdYf4=
 github.com/getkin/kin-openapi v0.104.0/go.mod h1:9Dhr+FasATJZjS4iOLvB0hkaxgYdulrNYm2e9epLWOo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a h1:v6zMvHuY9yue4+QkG/HQ/W67wvtQmWJ4SDo9aK/GIno=
+github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a/go.mod h1:I79BieaU4fxrw4LMXby6q5OS9XnoR9UIKLOzDFjUmuw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -84,6 +84,8 @@ const (
 	ErrMsgMarshallingJSONEtag            = "Error marshalling into JSON: %v"
 	ErrMsgNoParameters                   = "No parameter allowed"
 	ErrMsgNotSupportedFormat             = "Requested format %v not supported"
+	ErrMsgMalformedEtag                  = "Malformed etag detected %v"
+	ErrMsgCacheCleaningFailed            = "Server cache could not be cleaned"
 )
 
 // ==================================================

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -269,12 +269,11 @@ func NewCollectionsInfo(tables []*Table) *CollectionsInfo {
 
 // Generic representation of Db data
 type GeojsonFeatureData struct {
-	Type             string                 `json:"type"`
-	ID               string                 `json:"id,omitempty"`
-	Geom             *geojson.Geometry      `json:"geometry"`
-	Props            map[string]interface{} `json:"properties"`
-	WeakEtag         string                 `json:"-"`
-	LastModifiedDate string                 `json:"-"`
+	Type     string                 `json:"type"`
+	ID       string                 `json:"id,omitempty"`
+	Geom     *geojson.Geometry      `json:"geometry"`
+	Props    map[string]interface{} `json:"properties"`
+	WeakEtag *WeakEtagData          `json:"-"`
 }
 
 // Define a FeatureCollection structure for parsing test data
@@ -287,9 +286,9 @@ type FeatureCollection struct {
 	Links          []*Link               `json:"links"`
 }
 
-func MakeGeojsonFeatureJSON(id string, geom geojson.Geometry, props map[string]interface{}, weakEtag string, lastModifiedDate string) string {
+func MakeGeojsonFeatureJSON(tableName string, id string, geom geojson.Geometry, props map[string]interface{}, weakEtag string, lastModifiedDate string) string {
 
-	featData := MakeGeojsonFeature(id, geom, props, weakEtag, lastModifiedDate)
+	featData := MakeGeojsonFeature(tableName, id, geom, props, weakEtag, lastModifiedDate)
 	json, err := json.Marshal(featData)
 	if err != nil {
 		log.Errorf("Error marshalling feature into JSON: %v", err)
@@ -299,15 +298,15 @@ func MakeGeojsonFeatureJSON(id string, geom geojson.Geometry, props map[string]i
 	return jsonStr
 }
 
-func MakeGeojsonFeature(id string, geom geojson.Geometry, props map[string]interface{}, weakEtag string, lastModifiedHttpDate string) *GeojsonFeatureData {
+func MakeGeojsonFeature(tableName string, id string, geom geojson.Geometry, props map[string]interface{}, weakEtagStr string, lastModifiedHttpDate string) *GeojsonFeatureData {
 
+	weakEtag := MakeWeakEtag(tableName, id, weakEtagStr, lastModifiedHttpDate)
 	featData := GeojsonFeatureData{
-		Type:             "Feature",
-		ID:               id,
-		Geom:             &geom,
-		Props:            props,
-		WeakEtag:         weakEtag,
-		LastModifiedDate: lastModifiedHttpDate,
+		Type:     "Feature",
+		ID:       id,
+		Geom:     &geom,
+		Props:    props,
+		WeakEtag: weakEtag,
 	}
 	return &featData
 }

--- a/internal/api/etag.go
+++ b/internal/api/etag.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -23,20 +25,105 @@ import (
  Authors  : Nicolas Revelant (nicolas dot revelant at ign dot fr)
 */
 
-// Generic representation of a strong etag
-type StrongEtagData struct {
-	Collection string `json:"collection"`
-	Srid       int    `json:"srid"`
-	Format     string `json:"format"`
-	WeakEtag   string `json:"weaketag"`
+// Generic representation of a weak etag
+type WeakEtagData struct {
+	Collection   string                 `json:"collection"`
+	FeatureId    string                 `json:"fid"`
+	Etag         string                 `json:"etag"` // for example: xmin
+	LastModified string                 `json:"last-modified"`
+	Data         map[string]interface{} `json:"-"`
 }
 
-func MakeStrongEtag(collection string, srid int, format string, weakEtag string) *StrongEtagData {
+// Generic representation of a strong etag
+type StrongEtagData struct {
+	*WeakEtagData
+
+	Srid   int    `json:"srid"`
+	Format string `json:"format"`
+}
+
+// weak etag stringer function
+func (etag WeakEtagData) String() string {
+	return "W/\"" + etag.Etag + "\""
+}
+
+// return a key for a cache according to etag.
+// If the etag field is not set, return the alternate key
+func (etag WeakEtagData) CacheKey() string {
+	if etag.Etag != "" {
+		return fmt.Sprintf("ET-%s", etag.Etag)
+	}
+	return etag.AlternateCacheKey()
+}
+
+// return a key for a cache according to collection name and feature id.
+func (etag WeakEtagData) AlternateCacheKey() string {
+	return fmt.Sprintf("CF-%s-%s", etag.Collection, etag.FeatureId)
+}
+
+// Marshall etag to byte
+func (etag WeakEtagData) MarshalBinary() (data []byte, err error) {
+	bytes, err := json.Marshal(etag)
+	return bytes, err
+}
+
+// Unmarshall etag to byte
+func (etag *WeakEtagData) UnmarshalBinary(data []byte) error {
+	var tmp WeakEtagData
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	etag.Collection = tmp.Collection
+	etag.FeatureId = tmp.FeatureId
+	etag.Etag = tmp.Etag
+	etag.LastModified = tmp.LastModified
+	etag.Data = tmp.Data
+
+	return nil
+}
+
+// return a new pointer onto weak etag
+func MakeWeakEtag(collection string, fid string, weakEtag string, lastModified string) *WeakEtagData {
+	weakEtagData := WeakEtagData{
+		Collection:   collection,
+		FeatureId:    fid,
+		Etag:         weakEtag,
+		LastModified: lastModified,
+	}
+	return &weakEtagData
+}
+
+// strong etag stringer function
+func (sEtag StrongEtagData) String() string {
+	return fmt.Sprintf("%s-%s-%d-%s-%s", sEtag.WeakEtagData.Collection, sEtag.WeakEtagData.FeatureId,
+		sEtag.Srid, sEtag.Format, sEtag.WeakEtagData.Etag)
+}
+
+// base64 encoded version of String() function
+func (sEtag StrongEtagData) ToEncodedString() string {
+	return base64.StdEncoding.EncodeToString([]byte(sEtag.String()))
+}
+
+// returns a key for a cache
+func (sEtag StrongEtagData) CacheKey() string {
+	return sEtag.WeakEtagData.CacheKey()
+}
+
+// Marshall etag to byte
+func (etag StrongEtagData) MarshalBinary() (data []byte, err error) {
+	bytes, err := json.Marshal(etag)
+	return bytes, err
+}
+
+// return a new pointer onto strong etag
+func MakeStrongEtag(collection string, fid string, weakEtag string, lastModified string, srid int, format string) *StrongEtagData {
+	weakEtagData := MakeWeakEtag(collection, fid, weakEtag, lastModified)
 	strongEtagData := StrongEtagData{
-		Collection: collection,
-		Srid:       srid,
-		Format:     format,
-		WeakEtag:   weakEtag,
+		WeakEtagData: weakEtagData,
+		Srid:         srid,
+		Format:       format,
 	}
 	return &strongEtagData
 }
@@ -52,35 +139,41 @@ func DecodeStrongEtag(encodedStrongEtag string) (*StrongEtagData, error) {
 	decodedString := string(decodedStrongEtag)
 	decodedString = strings.Replace(decodedString, "\"", "", -1)
 	elements := strings.Split(decodedString, "-")
-	if len(elements) != 4 {
+	if len(elements) != 5 {
 		return nil, errors.New("strong etag contains a wrong number of elements")
 	}
 	collectionName := elements[0]
-	sridValue, err := strconv.Atoi(elements[1])
+	sridValue, err := strconv.Atoi(elements[2])
 	if err != nil {
 		return nil, errors.New("the provided srid value is not an int")
 	}
-	format, weakEtag := elements[2], elements[3]
-	return MakeStrongEtag(collectionName, sridValue, format, weakEtag), nil
+	fid, format, etag := elements[1], elements[3], elements[4]
+
+	return MakeStrongEtag(collectionName, fid, etag, "", sridValue, format), nil
 }
 
 // Returns a WeakEtag string from a etag. If etag starts with W/ value is split to get WeakEtag otherwise we decode etag to strong format to get WeakEtag
-func EtagToWeakEtag(strongEtag string) (string, error) {
+func EtagStrToObject(etagStr string) (*WeakEtagData, error) {
 
-	weakEtagValue := ""
-
-	// Weak Etag form
-	if strings.HasPrefix(strongEtag, "W/") {
-		weakEtagValue = strings.Split(strongEtag, "W/")[1]
-	} else {
-		// Strong Etag form
-		strongValue, err := DecodeStrongEtag(strongEtag)
-		if err != nil {
-			return "", errors.New("wrong strong etag format")
-		}
-		weakEtagValue = strongValue.WeakEtag
+	if etagStr == "" {
+		return nil, nil
 	}
 
-	weakEtagValue = strings.ReplaceAll(weakEtagValue, "\"", "")
-	return weakEtagValue, nil
+	// Weak Etag form
+	if strings.HasPrefix(etagStr, "W/") {
+		etagStr := strings.Split(etagStr, "W/")[1]
+		etagStr = strings.Replace(etagStr, "\"", "", -1)
+		weakEtag := MakeWeakEtag("", "", etagStr, "")
+		return weakEtag, nil
+
+	} else {
+		// Strong Etag form
+		strongEtag, err := DecodeStrongEtag(etagStr)
+		if err != nil {
+			return nil, errors.New("wrong strong etag format")
+		}
+
+		return strongEtag.WeakEtagData, nil
+	}
+
 }

--- a/internal/data/cache_disabled.go
+++ b/internal/data/cache_disabled.go
@@ -1,5 +1,7 @@
 package data
 
+import "github.com/CrunchyData/pg_featureserv/internal/api"
+
 /*
  Copyright 2022 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,11 +22,15 @@ type CacheDisabled struct {
 	// no-ope
 }
 
-func (cache CacheDisabled) ContainsWeakEtag(strongEtag string) (bool, error) {
+func (cache CacheDisabled) GetWeakEtag(etag interface{}) (*api.WeakEtagData, error) {
+	return nil, nil
+}
+
+func (cache CacheDisabled) ContainsEtag(etag interface{}) (bool, error) {
 	return false, nil
 }
 
-func (cache CacheDisabled) AddWeakEtag(weakEtag string, etag interface{}) (bool, error) {
+func (cache CacheDisabled) AddWeakEtag(weakEtag string, etag *api.WeakEtagData) (bool, error) {
 	return false, nil
 }
 
@@ -42,4 +48,8 @@ func (cache CacheDisabled) Type() string {
 
 func (cache CacheDisabled) Size() int {
 	return 0
+}
+
+func (cache CacheDisabled) Reset() (bool, error) {
+	return true, nil
 }

--- a/internal/data/cache_test/cache_redis_test.go
+++ b/internal/data/cache_test/cache_redis_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/CrunchyData/pg_featureserv/internal/api"
 	"github.com/CrunchyData/pg_featureserv/internal/data"
 	"github.com/CrunchyData/pg_featureserv/internal/util"
 )
@@ -39,49 +40,52 @@ func (t *CacheTests) TestRedisValidAddress() {
 
 		cache := data.CacheRedis{}
 		err := cache.Init(url, "")
-		util.Assert(t, err == nil, "No error in CacheRedis initialization expected")
-
-		util.Assert(t, cache.String() == "Redis Cache running on "+url, "Invalid CacheRedis string")
+		util.Equals(t, err, nil, "No error in CacheRedis initialization expected")
+		util.Equals(t, "Redis Cache running on "+url, cache.String(), "Invalid CacheRedis string")
 	})
 }
 
-func (t *CacheTests) TestRedisContainsWeakEtag() {
+func (t *CacheTests) TestRedisContainsEtag() {
 	url := t.RedisUrl
-	t.Test.Run("TestRedisContainsWeakEtag", func(t *testing.T) {
+	t.Test.Run("TestRedisContainsEtag", func(t *testing.T) {
 
 		cache := data.CacheRedis{}
 		err := cache.Init(url, "")
-		util.Assert(t, err == nil, "No error in CacheRedis initialization expected")
+		util.Equals(t, err, nil, "No error in CacheRedis initialization expected")
+
+		res, err := cache.Reset()
+		util.Equals(t, err, nil, "No error in CacheRedis reset expected")
+		util.Assert(t, res, "No error in CacheRedis reset expected")
 
 		// Test invalid etag use
-		_, err = cache.ContainsWeakEtag("invalid_val")
+		_, err = cache.ContainsEtag("invalid_val")
 		util.Assert(t, err != nil, "Invalid etag used for RedisCache, expecting failure")
 
-		validWeakEtag := "collection"
-		wValidWeakEtag := "W/" + validWeakEtag
+		validWeakEtag := api.MakeWeakEtag("collection", "1", "etag", "")
+		wValidWeakEtag := validWeakEtag.String()
 
 		// Test valid etag but not available
-		res, err := cache.ContainsWeakEtag(wValidWeakEtag)
-		util.Assert(t, err == nil, "No error expected with valid Etag use")
-		util.Assert(t, res == false, wValidWeakEtag+" Etag should not be available in Redis cache")
+		res, err = cache.ContainsEtag(wValidWeakEtag)
+		util.Equals(t, err, nil, "No error expected with valid Etag use")
+		util.Assert(t, !res, wValidWeakEtag+" Etag should not be available in Redis cache")
 
 		// Test contains after add
-		res, err = cache.AddWeakEtag(validWeakEtag, "value")
-		util.Assert(t, err == nil, "No error expected with valid Etag use")
+		res, err = cache.AddWeakEtag(validWeakEtag.CacheKey(), validWeakEtag)
+		util.Equals(t, err, nil, "No error expected with valid Etag use")
 		util.Assert(t, res, "Result should be true when adding a valid weak Etag")
 
-		res, err = cache.ContainsWeakEtag(wValidWeakEtag)
-		util.Assert(t, err == nil, "No error expected with valid Etag use")
+		res, err = cache.ContainsEtag(wValidWeakEtag)
+		util.Equals(t, err, nil, "No error expected with valid Etag use")
 		util.Assert(t, res, wValidWeakEtag+" Etag should be available in Redis cache")
 
 		// Test etag not available after remove
-		res, err = cache.RemoveWeakEtag(validWeakEtag)
-		util.Assert(t, err == nil, "No error expected with valid Etag use")
-		util.Assert(t, res, validWeakEtag+" Result should be true when removing an available weak etag")
+		res, err = cache.RemoveWeakEtag(validWeakEtag.CacheKey())
+		util.Equals(t, err, nil, "No error expected with valid Etag use")
+		util.Assert(t, res, wValidWeakEtag+" Result should be true when removing an available weak etag")
 
-		res, err = cache.ContainsWeakEtag(wValidWeakEtag)
-		util.Assert(t, err == nil, "No error expected with valid Etag use")
-		util.Assert(t, res == false, wValidWeakEtag+" Etag should not be available in Redis cache")
+		res, err = cache.ContainsEtag(wValidWeakEtag)
+		util.Equals(t, err, nil, "No error expected with valid Etag use")
+		util.Assert(t, !res, wValidWeakEtag+" Etag should not be available in Redis cache")
 	})
 }
 
@@ -97,8 +101,9 @@ func (t *CacheTests) TestRedisAddWeakEtag() {
 
 		initialSize := cache.Size()
 
+		weakEtagValue := api.WeakEtagData{}
 		//Test add a valid etag and check size update
-		res, err := cache.AddWeakEtag(validWeakEtag, "value")
+		res, err := cache.AddWeakEtag(validWeakEtag, &weakEtagValue)
 		util.Assert(t, err == nil, "No error expected with valid Etag use")
 		util.Assert(t, res, "Result should be true when adding a valid weak Etag")
 
@@ -131,8 +136,9 @@ func (t *CacheTests) TestRedisRemoveWeakEtag() {
 		util.Assert(t, err == nil, "No error expected with valid Etag use")
 		util.Assert(t, res == false, "Result should be false when removing a weak etag not available")
 
+		weakEtagValue := api.WeakEtagData{}
 		// Add etag and test removal
-		res, err = cache.AddWeakEtag(validWeakEtag, "value")
+		res, err = cache.AddWeakEtag(validWeakEtag, &weakEtagValue)
 		util.Assert(t, err == nil, "No error expected with valid Etag use")
 		util.Assert(t, res, "Result should be true when adding a valid weak Etag")
 
@@ -140,7 +146,7 @@ func (t *CacheTests) TestRedisRemoveWeakEtag() {
 		util.Assert(t, err == nil, "No error expected with valid Etag use")
 		util.Assert(t, res, validWeakEtag+" Result should be true when removing an available weak etag")
 
-		res, err = cache.ContainsWeakEtag(wValidWeakEtag)
+		res, err = cache.ContainsEtag(wValidWeakEtag)
 		util.Assert(t, err == nil, "No error expected with valid Etag use")
 		util.Assert(t, res == false, wValidWeakEtag+" Etag should not be available in Redis cache")
 	})

--- a/internal/data/cache_test/runner_cache_test.go
+++ b/internal/data/cache_test/runner_cache_test.go
@@ -47,7 +47,7 @@ func TestRunnerCache(t *testing.T) {
 		m.RedisUrl = redisCacheUrl
 		m.TestRedisInvalidAddress()
 		m.TestRedisValidAddress()
-		m.TestRedisContainsWeakEtag()
+		m.TestRedisContainsEtag()
 		m.TestRedisAddWeakEtag()
 		m.TestRedisRemoveWeakEtag()
 		afterEachRun()

--- a/internal/data/cacher.go
+++ b/internal/data/cacher.go
@@ -1,5 +1,11 @@
 package data
 
+import (
+	"reflect"
+
+	"github.com/CrunchyData/pg_featureserv/internal/api"
+)
+
 /*
  Copyright 2022 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +24,19 @@ package data
 
 type Cacher interface {
 
-	// returns true if the weak etag contained into the strong etag in argument is referenced into the cache
+	// returns true if the weak etag (etag is string - strong or weak etag - or *api.WeakEtagData) is referenced into the cache
 	// returns false otherwise
 	// an error will be returned if a malformed etag is detected
-	ContainsWeakEtag(strongEtag string) (bool, error)
+	ContainsEtag(etag interface{}) (bool, error)
+
+	// returns the object if the weak etag (etag is string - strong or weak etag - or *api.WeakEtagData) is referenced into the cache
+	// returns nil otherwise
+	// an error will be returned if a malformed etag is detected
+	GetWeakEtag(etag interface{}) (*api.WeakEtagData, error)
 
 	// adds the weak etag string into the cache and returns true if successful
 	// returns false if error occurs during the operation
-	AddWeakEtag(weakEtag string, etag interface{}) (bool, error)
+	AddWeakEtag(etagKey string, etagData *api.WeakEtagData) (bool, error)
 
 	// removes the weak etag string from the cache and returns true if successful
 	// returns false if error occurs during the operation
@@ -39,4 +50,48 @@ type Cacher interface {
 
 	// returns approx cache size
 	Size() int
+
+	// clean all cache content
+	Reset() (bool, error)
+}
+
+// IsOneEtagInCache checks if the weak value of at least one of the etags provided is present into the cache
+// Returns true at the first listed etag present into the cache, false otherwise
+// -> error != nil if a malformed etag is detected (wrong encoding, bad format.)
+// -> The provided etags have to be in their strong form and Base64 encoded
+func IsOneEtagInCache(cache Cacher, etagsList []string) (bool, error) {
+	for _, etag := range etagsList {
+		found, err := cache.ContainsEtag(etag)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// extracts etag from string (weak or strong etag received by http client) or from WeakEtagData or StrongEtagData
+func anyToEtag(cache Cacher, etag interface{}) (*api.WeakEtagData, error) {
+	var weakEtagValue *api.WeakEtagData = nil
+	var err error
+
+	typeE := reflect.TypeOf(etag).String()
+	if typeE == "string" { // from weak or strong etag string (from http client)
+		etagStr := etag.(string)
+		weakEtagValue, err = api.EtagStrToObject(etagStr)
+		if err != nil {
+			return nil, err
+		}
+
+	} else if typeE == "*api.WeakEtagData" {
+		weakEtagValue = etag.(*api.WeakEtagData)
+
+	} else if typeE == "*api.StrongEtagData" {
+		strongEtagValue := etag.(*api.StrongEtagData)
+		weakEtagValue = strongEtagValue.WeakEtagData
+	}
+
+	return weakEtagValue, nil
 }

--- a/internal/data/catalog.go
+++ b/internal/data/catalog.go
@@ -74,19 +74,6 @@ type Catalog interface {
 
 	FunctionData(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error)
 
-	// Add a weakEtag reference into the cache for a specific feature
-	// returns true of the operation have been successful, false otherwise
-	AddEtagToCache(weakEtag string, referenceContent map[string]interface{}) (bool, error)
-
-	// CheckStrongEtags checks if the weak value of at least one of the etags provided is present into the cache
-	// Returns false at the first listed etag present into the cache, true otherwise
-	// -> error != nil if a malformed etag is detected (wrong encoding, bad format.)
-	// -> The provided etags have to be in their strong form and Base64 encoded
-	CheckStrongEtags(etagsList []string) (bool, error)
-
-	// Reset the cache and its content with a new instance
-	CacheReset() bool
-
 	// GetCache returns a copy of the cache
 	GetCache() Cacher
 

--- a/internal/data/catalog.go
+++ b/internal/data/catalog.go
@@ -74,11 +74,18 @@ type Catalog interface {
 
 	FunctionData(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error)
 
-	// CheckStrongEtags checks if at least one of the etags provided is present into the cache
-	// Returns true at the first etag detected as present, false otherwise
+	// Add a weakEtag reference into the cache for a specific feature
+	// returns true of the operation have been successful, false otherwise
+	AddEtagToCache(weakEtag string, referenceContent map[string]interface{}) (bool, error)
+
+	// CheckStrongEtags checks if the weak value of at least one of the etags provided is present into the cache
+	// Returns false at the first listed etag present into the cache, true otherwise
 	// -> error != nil if a malformed etag is detected (wrong encoding, bad format.)
 	// -> The provided etags have to be in their strong form and Base64 encoded
 	CheckStrongEtags(etagsList []string) (bool, error)
+
+	// Reset the cache and its content with a new instance
+	CacheReset() bool
 
 	// GetCache returns a copy of the cache
 	GetCache() Cacher

--- a/internal/data/catalog_db_fun.go
+++ b/internal/data/catalog_db_fun.go
@@ -198,7 +198,7 @@ func (cat *catalogDB) FunctionFeatures(ctx context.Context, name string, args ma
 	sql, argValues := sqlGeomFunction(fn, args, propCols, param)
 	log.Debugf("Function features query: %v", sql)
 	log.Debugf("Function %v Args: %v", name, argValues)
-	features, err := readFeaturesWithArgs(ctx, cat.dbconn, sql, argValues, idColIndex, propCols, cat.cache)
+	features, err := readFeaturesWithArgs(ctx, cat.dbconn, sql, argValues, name, idColIndex, propCols, cat.cache)
 	return features, err
 }
 

--- a/internal/data/catalog_mock.go
+++ b/internal/data/catalog_mock.go
@@ -450,13 +450,18 @@ func (cat *CatalogMock) CheckStrongEtags(etagsList []string) (bool, error) {
 	for _, strongEtag := range etagsList {
 		found, err := cat.cache.ContainsWeakEtag(strongEtag)
 		if err != nil {
-			return false, err
+			return true, err
 		}
 		if found {
-			return true, nil
+			return false, nil
 		}
 	}
-	return false, nil
+	return true, nil
+}
+
+func (cat *CatalogMock) CacheReset() bool {
+	cat.cache = makeCache()
+	return true
 }
 
 func (cat *CatalogMock) Functions() ([]*api.Function, error) {
@@ -481,4 +486,8 @@ func (cat *CatalogMock) FunctionFeatures(ctx context.Context, name string, args 
 func (cat *CatalogMock) FunctionData(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error) {
 	// TODO:
 	return nil, nil
+}
+
+func (cat *CatalogMock) AddEtagToCache(weakEtag string, referenceContent map[string]interface{}) (bool, error) {
+	return cat.cache.AddWeakEtag(weakEtag, referenceContent)
 }

--- a/internal/data/feature_mock.go
+++ b/internal/data/feature_mock.go
@@ -38,28 +38,26 @@ func makeFeatureMockPoint(id int, x float64, y float64) *featureMock {
 	sum := fnv.New32a()
 	encodedContent, _ := json.Marshal(geom)
 	sum.Write(encodedContent)
-	weakEtag := fmt.Sprint(sum.Sum32())
 
 	httpDateString := api.GetCurrentHttpDate() // Last modified value
 
 	idstr := strconv.Itoa(id)
 
 	feat := featureMock{
-		GeojsonFeatureData: api.GeojsonFeatureData{
-			Type:             "Feature",
-			ID:               idstr,
-			Geom:             geom,
-			Props:            map[string]interface{}{"prop_a": "propA", "prop_b": id, "prop_c": "propC", "prop_d": id % 10},
-			WeakEtag:         weakEtag,
-			LastModifiedDate: httpDateString,
-		},
+		GeojsonFeatureData: *api.MakeGeojsonFeature(
+			"",
+			idstr,
+			*geom,
+			map[string]interface{}{"prop_a": "propA", "prop_b": id, "prop_c": "propC", "prop_d": id % 10},
+			fmt.Sprint(sum.Sum32()),
+			httpDateString),
 	}
 	return &feat
 }
 
 func (fm *featureMock) toJSON(propNames []string) string {
 	props := fm.extractProperties(propNames)
-	return api.MakeGeojsonFeatureJSON(fm.ID, *fm.Geom, props, fm.WeakEtag, fm.LastModifiedDate)
+	return api.MakeGeojsonFeatureJSON("", fm.ID, *fm.Geom, props, fm.WeakEtag.Etag, fm.WeakEtag.LastModified)
 }
 
 func (fm *featureMock) extractProperties(propNames []string) map[string]interface{} {

--- a/internal/service/db_test/handler_db_etag_test.go
+++ b/internal/service/db_test/handler_db_etag_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/CrunchyData/pg_featureserv/internal/api"
 	"github.com/CrunchyData/pg_featureserv/internal/data"
 	"github.com/CrunchyData/pg_featureserv/internal/util"
+	"github.com/go-http-utils/headers"
 )
 
 func (t *DbTests) TestCacheActivationDb() {
@@ -82,7 +83,7 @@ func (t *DbTests) TestWeakEtagStableOnRequestsDb() {
 	t.Test.Run("TestWeakEtagStableOnRequestsDb", func(t *testing.T) {
 		path := "/collections/mock_b/items/1"
 		var headerJson = make(http.Header)
-		headerJson.Add("Accept", api.ContentTypeJSON)
+		headerJson.Add(headers.Accept, api.ContentTypeJSON)
 
 		resp := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), headerJson, http.StatusOK)
 		encodedStrongEtag1 := resp.Header().Get("Etag")
@@ -100,78 +101,20 @@ func (t *DbTests) TestWeakEtagStableOnRequestsDb() {
 	})
 }
 
-func (t *DbTests) TestEtagHeaderIfNoneMatchDb() {
-	t.Test.Run("TestEtagHeaderIfNoneMatchDb", func(t *testing.T) {
-		path := "/collections/mock_a/items/1"
-
-		// first GET prefetches the etag into the server cache
-		resp := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), nil, http.StatusOK)
-
-		strongEtagFromServer := resp.Header().Get("ETag")
-
-		var header = make(http.Header)
-		header.Add("If-None-Match", strongEtagFromServer)
-		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusNotModified)
-	})
-}
-
-func (t *DbTests) TestEtagHeaderIfNonMatchAfterReplaceDb() {
-	t.Test.Run("TestEtagHeaderIfNonMatchAfterReplaceDb", func(t *testing.T) {
-		path := "/collections/mock_a/items/1"
-		resp := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), nil, http.StatusOK)
-		strongEtagFromServer := resp.Header().Get("Etag")
-
-		// If-None-Match before replace
-		var header = make(http.Header)
-		header.Add("If-None-Match", strongEtagFromServer)
-		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusNotModified)
-
-		// Replace
-		var headerPut = make(http.Header)
-		headerPut.Add("Accept", api.ContentTypeSchemaPatchJSON)
-		jsonStr := `{
-			"type": "Feature",
-			"id": "1",
-			"geometry": {
-				"type": "Point",
-				"coordinates": [
-				-120,
-				40
-				]
-			},
-			"properties": {
-				"prop_a": "propA...",
-				"prop_b": 1,
-				"prop_c": "propC...",
-				"prop_d": 1
-			}
-		}`
-		hTest.DoRequestMethodStatus(t, "PUT", path, []byte(jsonStr), headerPut, http.StatusNoContent)
-
-		// TODO : test will be OK once merge done with trigger
-
-		// If-None-Match after replace
-		// resp2 := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusOK)
-		// strongEtagAfterPut := resp2.Header().Get("Etag")
-
-		// util.Assert(t, strongEtagFromServer != strongEtagAfterPut, "strong etag value is still the same after replace!")
-	})
-}
-
 func (t *DbTests) TestEtagHeaderIfNonMatchMalformedEtagDb() {
 	t.Test.Run("TestEtagHeaderIfNonMatchMalformedEtagDb", func(t *testing.T) {
 		path := "/collections/mock_a/items/1"
 
 		var header = make(http.Header)
-		header.Add("If-None-Match", "\"unknown_etag\"")
+		header.Add(headers.IfNoneMatch, "\"unknown_etag\"")
 		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusBadRequest)
 
 		var header2 = make(http.Header)
-		header2.Add("If-None-Match", "\"mock_a-4326-json-812\"")
+		header2.Add(headers.IfNoneMatch, "\"mock_a-4326-json-812\"")
 		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header2, http.StatusBadRequest)
 
 		var header3 = make(http.Header)
-		header3.Add("If-None-Match", "mock_a-4326-json-812")
+		header3.Add(headers.IfNoneMatch, "mock_a-4326-json-812")
 		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header3, http.StatusBadRequest)
 	})
 }
@@ -192,7 +135,7 @@ func (t *DbTests) TestEtagHeaderIfNonMatchVariousEtagsDb() {
 		var header = make(http.Header)
 		etags := []string{encodedWrongEtag1, encodedWrongEtag2, encodedValidEtagFromServer}
 		headerValue := strings.Join(etags, ",")
-		header.Add("If-None-Match", headerValue)
+		header.Add(headers.IfNoneMatch, headerValue)
 		hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusNotModified)
 	})
 }
@@ -209,7 +152,7 @@ func (t *DbTests) TestEtagHeaderIfNonMatchWeakEtagDb() {
 		// strong-etag => "<collection>-<srid>-<format>-<weakEtag>"
 		weakEtag := "W/" + "\"" + decodedStrongEtag.WeakEtag + "\""
 		var header = make(http.Header)
-		header.Add("If-None-Match", weakEtag)
+		header.Add(headers.IfNoneMatch, weakEtag)
 		hTest.DoRequestMethodStatus(t, "GET", path, nil, header, http.StatusNotModified)
 	})
 }
@@ -224,7 +167,7 @@ func (t *DbTests) TestEtagReplaceFeatureDb() {
 	t.Test.Run("TestEtagReplaceFeatureDb", func(t *testing.T) {
 		path := "/collections/mock_b/items/1"
 		var header = make(http.Header)
-		header.Add("Accept", api.FormatJSON)
+		header.Add(headers.Accept, api.FormatJSON)
 
 		jsonStr := `{
 			"type": "Feature",
@@ -252,7 +195,7 @@ func (t *DbTests) TestEtagReplaceFeatureDb() {
 
 		// Replace
 		var header2 = make(http.Header)
-		header.Add("Accept", api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
 		hTest.DoRequestMethodStatus(t, "PUT", path, []byte(jsonStr), header2, http.StatusNoContent)
 
 		resp2 := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), header, http.StatusOK)

--- a/internal/service/db_test/handler_db_etag_test.go
+++ b/internal/service/db_test/handler_db_etag_test.go
@@ -158,7 +158,7 @@ func (t *DbTests) TestEtagHeaderIfNonMatchWeakEtagDb() {
 
 func (t *DbTests) TestEtagHeaderIfMatchDb() {
 	t.Test.Run("TestEtagHeaderIfMatchDb", func(t *testing.T) {
-		// TODO
+		// TODO not implemented
 	})
 }
 

--- a/internal/service/db_test/handler_db_if-non-match_test.go
+++ b/internal/service/db_test/handler_db_if-non-match_test.go
@@ -1,0 +1,298 @@
+package db_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/CrunchyData/pg_featureserv/internal/api"
+	"github.com/CrunchyData/pg_featureserv/internal/util"
+	"github.com/go-http-utils/headers"
+)
+
+/*
+ Copyright 2022 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Date     : November 2022
+ Authors  : Nicolas Revelant (nicolas dot revelant at ign dot fr)
+
+*/
+
+func (t *DbTests) TestGetFeatureIfNoneMatchStaValueWithEtagPresentInCacheDb() {
+	t.Test.Run("TestGetFeatureIfNoneMatchStaValueWithEtagPresentInCacheDb", func(t *testing.T) {
+
+		getFeatureEtag(t, "mock_a", 1) // Prefetching an etag in cache
+
+		var header = make(http.Header)
+		header.Add(headers.IfNoneMatch, "*")
+		hTest.DoRequestMethodStatus(t, "GET", "/collections/mock_a/items/1", []byte(""), header, http.StatusNotModified)
+	})
+}
+
+func (t *DbTests) TestGetFeatureIfNoneMatchStaValueWithNoEtagDb() {
+	t.Test.Run("TestGetFeatureIfNoneMatchStaValueWithNoEtagDb", func(t *testing.T) {
+
+		purgeCacheFromAllEtags(t)
+
+		var header = make(http.Header)
+		header.Add(headers.IfNoneMatch, "*")
+		hTest.DoRequestMethodStatus(t, "GET", "/collections/mock_a/items/1", []byte(""), header, http.StatusOK)
+	})
+}
+
+func (t *DbTests) TestGetFeatureIfNonMatchAfterReplaceDb() {
+	t.Test.Run("TestGetFeatureIfNonMatchAfterReplaceDb", func(t *testing.T) {
+
+		strongEtagFromServer := getFeatureEtag(t, "mock_a", 1)
+
+		// If-None-Match before replace
+		var header = make(http.Header)
+		header.Add(headers.IfNoneMatch, strongEtagFromServer)
+		hTest.DoRequestMethodStatus(t, "GET", "/collections/mock_a/items/1", []byte(""), header, http.StatusNotModified)
+
+		// Replace
+		var headerPut = make(http.Header)
+		headerPut.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		jsonStr := `{
+			"type": "Feature",
+			"id": "1",
+			"geometry": {
+				"type": "Point",
+				"coordinates": [
+				-120,
+				40
+				]
+			},
+			"properties": {
+				"prop_a": "propA...",
+				"prop_b": 1,
+				"prop_c": "propC...",
+				"prop_d": 1
+			}
+		}`
+		hTest.DoRequestMethodStatus(t, "PUT", "/collections/mock_a/items/1", []byte(jsonStr), headerPut, http.StatusNoContent)
+
+		// If-None-Match after replace
+		strongEtagAfterPut := getFeatureEtag(t, "mock_a", 1)
+		util.Assert(t, strongEtagFromServer != strongEtagAfterPut, "strong etag value is still the same after replace!")
+	})
+}
+
+func (t *DbTests) TestUpdateFeatureIfNoneMatchWithEtagPresentInCacheDb() {
+	t.Test.Run("TestUpdateFeatureIfNoneMatchWithEtagPresentInCache", func(t *testing.T) {
+		// If-None-Match header + PATCH with an etag detected in cache
+		// -> 412 Precondition failed
+
+		encodedEtagFromServer := getFeatureEtag(t, "mock_a", 1)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, encodedEtagFromServer)
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-500, 800}, "PATCH", path, header, http.StatusPreconditionFailed, [2]int{-120, 40})
+
+	})
+}
+
+func (t *DbTests) TestUpdateFeatureIfNoneMatchWithEtagNotDetectedDb() {
+	t.Test.Run("TestUpdateFeatureIfNoneMatchWithEtagNotDetected", func(t *testing.T) {
+		// If-None-Match header + PATCH with Etag not present in Cache
+		// -> 204 "No Content"
+
+		encodedEtagFromServer := getFeatureEtag(t, "mock_a", 1)
+
+		purgeCacheFromAllEtags(t)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, encodedEtagFromServer)
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-500, 800}, "PATCH", path, header, http.StatusNoContent, [2]int{-500, 800})
+	})
+}
+
+func (t *DbTests) TestUpdateFeatureIfNoneMatchStarValueWithExistingRepresentationInCacheDb() {
+	t.Test.Run("TestUpdateFeatureIfNoneMatchStarValueWithExistingRepresentationInCache", func(t *testing.T) {
+		// If-None-Match header + PATCH with an etag detected in cache
+		// -> 412 Precondition failed
+
+		getFeatureEtag(t, "mock_a", 1) // Prefetching an etag in cache
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, "*")
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-9000, 8000}, "PATCH", path, header, http.StatusPreconditionFailed, [2]int{-500, 800})
+	})
+}
+
+func (t *DbTests) TestUpdateFeatureIfNoneMatchStarValueWithNoRepresentationInCacheDb() {
+	t.Test.Run("TestUpdateFeatureIfNoneMatchStarValueWithNoRepresentationInCache", func(t *testing.T) {
+		// IfNoneMatch "*" PATCH without any Etag present in cache
+		// -> 204 No content
+
+		purgeCacheFromAllEtags(t)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, "*")
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-9000, 8000}, "PATCH", path, header, http.StatusNoContent, [2]int{-9000, 8000})
+	})
+}
+
+func (t *DbTests) TestReplaceFeatureIfNoneMatchWithEtagPresentInCacheDb() {
+	t.Test.Run("TestReplaceFeatureIfNoneMatchWithEtagPresentInCache", func(t *testing.T) {
+		// If-None-Match header + PUT with an etag detected in cache
+		// -> 412 Precondition failed
+
+		encodedEtagFromServer := getFeatureEtag(t, "mock_a", 1)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, encodedEtagFromServer)
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-9002, 8002}, "PUT", path, header, http.StatusPreconditionFailed, [2]int{-9000, 8000})
+	})
+}
+
+func (t *DbTests) TestReplaceFeatureIfNoneMatchWithEtagNotDetectedDb() {
+	t.Test.Run("TestReplaceFeatureIfNoneMatchWithEtagNotDetected", func(t *testing.T) {
+		// If-None-Match header + PUT with Etag not present in Cache
+		// -> 204 "No Content"
+
+		encodedEtagFromServer := getFeatureEtag(t, "mock_a", 1)
+
+		purgeCacheFromAllEtags(t)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, encodedEtagFromServer)
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-501, 801}, "PUT", path, header, http.StatusNoContent, [2]int{-501, 801})
+	})
+
+}
+
+func (t *DbTests) TestReplaceFeatureIfNoneMatchStarValueWithNoRepresentationInCacheDb() {
+	t.Test.Run("TestReplaceFeatureIfNoneMatchStarValueWithNoRepresentationInCache", func(t *testing.T) {
+		// IfNoneMatch "*" PUT without any Etag present in cache
+		// -> 204 No content
+
+		purgeCacheFromAllEtags(t)
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, "*")
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-9009, 8009}, "PUT", path, header, http.StatusNoContent, [2]int{-9009, 8009})
+	})
+}
+
+func (t *DbTests) TestReplaceFeatureIfNoneMatchStarValueWithExistingRepresentationInCacheDb() {
+	t.Test.Run("TestReplaceFeatureIfNoneMatchStarValueWithExistingRepresentationInCache", func(t *testing.T) {
+		// If-None-Match header + PUT with an etag detected in cache
+		// -> 412 Precondition failed
+
+		getFeatureEtag(t, "mock_a", 1) // Prefetching an etag in cache
+
+		var header = make(http.Header)
+		header.Add(headers.Accept, api.ContentTypeSchemaPatchJSON)
+		header.Add(headers.IfNoneMatch, "*")
+
+		path := "/collections/mock_a/items/1"
+		// checkFeatureModification(t , requestedCoords , method, path, header, expectedStatus, expectedCoords)
+		checkFeatureModification(t, [2]int{-9000, 8000}, "PUT", path, header, http.StatusPreconditionFailed, [2]int{-9009, 8009})
+
+	})
+}
+
+// cleans the catalog cache by instantiating a new cache structure with a void map entries
+func purgeCacheFromAllEtags(t *testing.T) {
+	purgePath := "/etags/purge"
+	hTest.DoRequestStatus(t, purgePath, http.StatusOK)
+}
+
+// send a GET request on the wanted feature /collections/{collectionName}/items/{feature_id}
+// and returns the etag obtained into the response
+func getFeatureEtag(t *testing.T, collectionName string, featureId int) string {
+	path := "/collections/" + collectionName + "/items/" + strconv.Itoa(featureId)
+	resp := hTest.DoRequestMethodStatus(t, "GET", path, []byte(""), nil, http.StatusOK)
+	return resp.Header().Get("Etag")
+}
+
+// send a GET request on the specified feature id and collection
+// and returns a JSON formatted version of the feature data
+func getFeatureAsJson(t *testing.T, collectionName string, featureId int) map[string]interface{} {
+	feature := checkItem(t, "mock_a", 1)
+	var jsonData map[string]interface{}
+	errUnMarsh := json.Unmarshal(feature, &jsonData)
+	util.Assert(t, errUnMarsh == nil, fmt.Sprintf("%v", errUnMarsh))
+	return jsonData
+}
+
+func checkFeatureModification(t *testing.T, requestedCoords [2]int, method string, path string, header http.Header, expectedStatus int, expectedCoords [2]int) {
+
+	jsonStr := fmt.Sprintf(`{
+		"type": "Feature",
+		"id": "1",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [
+			%d,
+			%d
+			]
+		},
+		"properties": {
+			"prop_a": "propA...",
+			"prop_b": 1,
+			"prop_c": "propC...",
+			"prop_d": 1
+		}
+	}`,
+		requestedCoords[0],
+		requestedCoords[1],
+	)
+
+	_ = hTest.DoRequestMethodStatus(t, method, path, []byte(jsonStr), header, expectedStatus)
+
+	// checking the feature data are still the same
+	jsonData := getFeatureAsJson(t, "mock_a", 1)
+
+	geom := jsonData["geometry"].(map[string]interface{})
+	util.Equals(t, "Point", geom["type"].(string), "feature Type")
+	coordinate := geom["coordinates"].([]interface{})
+	if requestedCoords != expectedCoords {
+		util.Equals(t, expectedCoords[0], int(coordinate[0].(float64)), "feature latitude not updated!")
+		util.Equals(t, expectedCoords[1], int(coordinate[1].(float64)), "feature longitude not updated!")
+	} else {
+		util.Equals(t, expectedCoords[0], int(coordinate[0].(float64)), "feature latitude has been modified!")
+		util.Equals(t, expectedCoords[1], int(coordinate[1].(float64)), "feature longitude has been modified!")
+	}
+
+}

--- a/internal/service/db_test/runner_db_test.go
+++ b/internal/service/db_test/runner_db_test.go
@@ -138,6 +138,7 @@ func TestRunnerHandlerDb(t *testing.T) {
 		// (too many INSERTs and DELETEs at the same time)
 		cat.Initialize(nil, nil)
 		test.TestCacheSizeIncreaseAfterCreate()
+		test.TestCacheSizeIncreaseAfterCreateComplex()
 		test.TestCacheSizeDecreaseAfterDelete()
 		test.TestCacheModifiedAfterUpdate()
 		afterEachRun()

--- a/internal/service/db_test/runner_db_test.go
+++ b/internal/service/db_test/runner_db_test.go
@@ -70,29 +70,13 @@ func TestMain(m *testing.M) {
 
 // Describes all test groups
 func TestRunnerHandlerDb(t *testing.T) {
-	// initialisation avant l'execution des tests
+	// tests intialization
 	beforeRun()
 
 	t.Run("Init", func(t *testing.T) {
 		beforeEachRun()
 		test := DbTests{Test: t}
 		test.TestProperDbInit()
-		afterEachRun()
-	})
-	t.Run("CACHE", func(t *testing.T) {
-		beforeEachRun()
-		test := DbTests{Test: t}
-		test.TestCacheActivationDb()
-		test.TestLastModifiedDb()
-		test.TestEtagDb()
-		test.TestWeakEtagStableOnRequestsDb()
-		test.TestEtagHeaderIfNoneMatchDb()
-		test.TestEtagHeaderIfNonMatchAfterReplaceDb()
-		test.TestEtagHeaderIfNonMatchMalformedEtagDb()
-		test.TestEtagHeaderIfNonMatchVariousEtagsDb()
-		test.TestEtagHeaderIfNonMatchWeakEtagDb()
-		test.TestEtagHeaderIfMatchDb()
-		test.TestEtagReplaceFeatureDb()
 		afterEachRun()
 	})
 	t.Run("GET", func(t *testing.T) {
@@ -102,7 +86,6 @@ func TestRunnerHandlerDb(t *testing.T) {
 		test.TestPropertiesAllFromDbComplexTable()
 		afterEachRun()
 	})
-	// liste de tests sur la suppression des features
 	t.Run("DELETE", func(t *testing.T) {
 		beforeEachRun()
 		test := DbTests{Test: t}
@@ -134,6 +117,20 @@ func TestRunnerHandlerDb(t *testing.T) {
 		test.TestUpdateSimpleFeatureDb()
 		afterEachRun()
 	})
+	t.Run("CACHE-ETAGS", func(t *testing.T) {
+		beforeEachRun()
+		test := DbTests{Test: t}
+		test.TestCacheActivationDb()
+		test.TestLastModifiedDb()
+		test.TestEtagDb()
+		test.TestWeakEtagStableOnRequestsDb()
+		test.TestEtagHeaderIfNonMatchMalformedEtagDb()
+		test.TestEtagHeaderIfNonMatchVariousEtagsDb()
+		test.TestEtagHeaderIfNonMatchWeakEtagDb()
+		test.TestEtagHeaderIfMatchDb()
+		test.TestEtagReplaceFeatureDb()
+		afterEachRun()
+	})
 	t.Run("Listen", func(t *testing.T) {
 		beforeEachRun()
 		test := DbTests{Test: t}
@@ -145,8 +142,24 @@ func TestRunnerHandlerDb(t *testing.T) {
 		test.TestCacheModifiedAfterUpdate()
 		afterEachRun()
 	})
+	t.Run("HEADER-IF-NON-MATCH", func(t *testing.T) {
+		beforeEachRun()
+		test := DbTests{Test: t}
+		test.TestGetFeatureIfNoneMatchStaValueWithEtagPresentInCacheDb()
+		test.TestGetFeatureIfNoneMatchStaValueWithNoEtagDb()
+		test.TestGetFeatureIfNonMatchAfterReplaceDb()
+		test.TestUpdateFeatureIfNoneMatchWithEtagPresentInCacheDb()
+		test.TestUpdateFeatureIfNoneMatchWithEtagNotDetectedDb()
+		test.TestUpdateFeatureIfNoneMatchStarValueWithExistingRepresentationInCacheDb()
+		test.TestUpdateFeatureIfNoneMatchStarValueWithNoRepresentationInCacheDb()
+		test.TestReplaceFeatureIfNoneMatchWithEtagPresentInCacheDb()
+		test.TestReplaceFeatureIfNoneMatchWithEtagNotDetectedDb()
+		test.TestReplaceFeatureIfNoneMatchStarValueWithNoRepresentationInCacheDb()
+		test.TestReplaceFeatureIfNoneMatchStarValueWithExistingRepresentationInCacheDb()
+		afterEachRun()
+	})
 
-	// nettoyage après execution des tests
+	// after tests cleaning
 	afterRun()
 }
 

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -22,7 +22,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -75,15 +74,23 @@ func InitRouter(basePath string) *mux.Router {
 	addRoute(router, "/collections.{fmt}", handleCollections)
 
 	addRoute(router, "/collections/{cid}", handleCollection)
+	addRoute(router, "/collections/{cid}.{fmt}", handleCollection)
 
 	addRoute(router, "/collections/{cid}/items", handleCollectionItems)
 	addRoute(router, "/collections/{cid}/items.{fmt}", handleCollectionItems)
+
 	addRouteWithMethod(router, "/collections/{cid}/items", handleCreateCollectionItem, "POST")
+
 	addRouteWithMethod(router, "/collections/{cid}/items/{fid}", handleDeleteCollectionItem, "DELETE")
 
 	addRoute(router, "/collections/{cid}/schema", handleCollectionSchemas)
 
 	addRoute(router, "/collections/{cid}/items/{fid}", handleItem)
+	addRoute(router, "/collections/{cid}/items/{fid}.{fmt}", handleItem)
+	addRouteWithMethod(router, "/collections/{cid}/items/{fid}", handleItem, "PUT")
+	addRouteWithMethod(router, "/collections/{cid}/items/{fid}.{fmt}", handleItem, "PUT")
+	addRouteWithMethod(router, "/collections/{cid}/items/{fid}", handleItem, "PATCH")
+	addRouteWithMethod(router, "/collections/{cid}/items/{fid}.{fmt}", handleItem, "PATCH")
 
 	addRoute(router, "/functions", handleFunctions)
 	addRoute(router, "/functions.{fmt}", handleFunctions)
@@ -189,7 +196,8 @@ func handleDecodeStrongEtag(w http.ResponseWriter, r *http.Request) *appError {
 }
 
 func handlePurgeEtagsInCache(w http.ResponseWriter, r *http.Request) *appError {
-	if catalogInstance.CacheReset() {
+	ok, err := catalogInstance.GetCache().Reset()
+	if ok && err == nil {
 		writeResponse(w, api.ContentTypeText, []byte("cache cleaned successfully"))
 		return nil
 	}
@@ -648,8 +656,8 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 	query := api.URLQuery(r.URL)
 
 	//--- extract request parameters
-	tableName := getRequestVar(routeVarFeatureID, r)
-	fid := getRequestVar(routeVarFeatureID, r)
+	tableName := getRequestVar(routeVarCollectionID, r)
+	fid := getRequestVarStrip(routeVarFeatureID, r)
 	reqParam, err := parseRequestParams(r)
 	if err != nil {
 		return appErrorBadRequest(err, err.Error())
@@ -673,7 +681,7 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 	// - If-Range
 	// - Range
 
-	var eTagsList = make([]string, 1)
+	var eTagsList = make([]string, 0)
 	var checkPrecondition = false
 	var precondition = false
 
@@ -686,41 +694,29 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 			// "*" value prevents an unsafe request method (e.g., PUT) from inadvertently modifying an
 			// existing representation of the target resource when the client believes that the resource does
 			// not have a current representation : https://www.rfc-editor.org/rfc/rfc7232.html#section-3.2
-
-			// TODO : This section currently allows to retrieve the weak etag from database.
-			// But it will have to be deleted when we will be able to found easily the weak etag into the cache
-			// starting from the collection name and the feature id.
-			// This supposes a necessary modification of the cache structure
 			// ------------------------------------------------------------------------------------------------
-			reqParam, err := parseRequestParams(r)
+			weakEtag := api.MakeWeakEtag(tableName, fid, "", "")
+			weakEtag, err = catalogInstance.GetCache().GetWeakEtag(weakEtag)
 			if err != nil {
-				return appErrorBadRequest(err, err.Error())
+				return appErrorInternal(err, api.ErrMsgDataReadError, tableName)
 			}
-			param, errQuery := createQueryParams(&reqParam, tbl.Columns, tbl.Srid)
-			if errQuery == nil {
-				ctx := r.Context()
-				feature, err := catalogInstance.TableFeature(ctx, tableName, fid, param)
-				if err != nil {
-					return appErrorInternal(err, api.ErrMsgDataReadError, tableName)
-				}
-				if feature == nil {
-					return appErrorNotFound(nil, api.ErrMsgFeatureNotFound, fid)
-				}
-				weakEtag := "W/\"" + feature.WeakEtag + "\""
-				eTagsList[0] = weakEtag
-			} else {
-				return appErrorBadRequest(errQuery, api.ErrMsgInvalidQuery)
+			if weakEtag != nil {
+				weakEtagStr := weakEtag.String()
+				eTagsList = append(eTagsList, weakEtagStr)
 			}
+
 			// ------------------------------------------------------------------------------------------------
 		} else {
 			eTagsList = strings.Split(ifNoneMatchValue, ",")
 		}
 
-		precondition, err = catalogInstance.CheckStrongEtags(eTagsList)
+		present, err := data.IsOneEtagInCache(catalogInstance.GetCache(), eTagsList)
 		if err != nil {
 			return appErrorBadRequest(err, "Malformed etags")
 		}
 
+		// to respect RFC the precondition is false when one etag is present.
+		precondition = !present
 	}
 
 	// Performing request according to its method
@@ -868,20 +864,25 @@ func writeItemJSON(ctx context.Context, w http.ResponseWriter, tableName string,
 		return appErrorInternal(err, api.ErrMsgMarshallingJSON, tableName, feature.ID)
 	}
 
-	strongEtag := fmt.Sprintf(`"%s-%d-%s-%s"`, tableName, crs, "json", feature.WeakEtag)
-	encodedStrongEtag := base64.StdEncoding.EncodeToString([]byte(strongEtag))
+	strongEtag := api.MakeStrongEtag(feature.WeakEtag.Collection, feature.WeakEtag.FeatureId, feature.WeakEtag.Etag,
+		feature.WeakEtag.LastModified, crs, "json")
+	encodedStrongEtag := strongEtag.ToEncodedString()
 	w.Header().Set("Etag", encodedStrongEtag)
-	w.Header().Set("Last-Modified", feature.LastModifiedDate)
+	w.Header().Set("Last-Modified", strongEtag.WeakEtagData.LastModified)
 
+	// TODO should not be here! What if the output format is html?
 	// Check the etag presence into the cache, and add it if necessary
-	weakEtagToCheck := "W/\"" + feature.WeakEtag + "\""
-	notPresent, err := catalogInstance.CheckStrongEtags([]string{weakEtagToCheck})
+	weakEtagStr := strongEtag.WeakEtagData.String()
+	present, err := data.IsOneEtagInCache(catalogInstance.GetCache(), []string{weakEtagStr})
 	if err != nil {
-		return appErrorBadRequest(err, api.ErrMsgMalformedEtag, weakEtagToCheck)
+		return appErrorBadRequest(err, api.ErrMsgMalformedEtag, weakEtagStr)
 	}
-	if notPresent {
+	if !present {
+		// ===== DOUBLE ADD!!
 		//nolint:errcheck
-		catalogInstance.AddEtagToCache(feature.WeakEtag, map[string]interface{}{"last-modified": feature.LastModifiedDate})
+		catalogInstance.GetCache().AddWeakEtag(strongEtag.WeakEtagData.CacheKey(), strongEtag.WeakEtagData)
+		//nolint:errcheck
+		catalogInstance.GetCache().AddWeakEtag(strongEtag.WeakEtagData.AlternateCacheKey(), strongEtag.WeakEtagData)
 	}
 
 	writeResponse(w, api.ContentTypeGeoJSON, encodedContent)

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/CrunchyData/pg_featureserv/internal/data"
 	"github.com/CrunchyData/pg_featureserv/internal/ui"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-http-utils/headers"
 	"github.com/gorilla/mux"
 )
 
@@ -62,6 +63,7 @@ func InitRouter(basePath string) *mux.Router {
 	addRoute(router, "/index.{fmt}", handleRoot)
 
 	addRoute(router, "/etags/decodestrong/{etag}", handleDecodeStrongEtag)
+	addRoute(router, "/etags/purge", handlePurgeEtagsInCache)
 
 	addRoute(router, "/api", handleAPI)
 	addRoute(router, "/api.{fmt}", handleAPI)
@@ -82,10 +84,6 @@ func InitRouter(basePath string) *mux.Router {
 	addRoute(router, "/collections/{cid}/schema", handleCollectionSchemas)
 
 	addRoute(router, "/collections/{cid}/items/{fid}", handleItem)
-
-	addRouteWithMethod(router, "/collections/{cid}/items/{fid}", handlePartialUpdateItem, "PATCH")
-
-	addRouteWithMethod(router, "/collections/{cid}/items/{fid}", handleReplaceItem, "PUT")
 
 	addRoute(router, "/functions", handleFunctions)
 	addRoute(router, "/functions.{fmt}", handleFunctions)
@@ -116,7 +114,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request) *appError {
 }
 
 func doRoot(w http.ResponseWriter, r *http.Request, format string) *appError {
-	//log.Printf("Content-Type: %v  Accept: %v", r.Header.Get("Content-Type"), r.Header.Get("Accept"))
+	//log.Printf("Content-Type: %v  Accept: %v", r.Header.Get("Content-Type"), r.Header.Get(headers.Accept))
 	urlBase := serveURLBase(r)
 
 	// --- create content
@@ -188,6 +186,14 @@ func handleDecodeStrongEtag(w http.ResponseWriter, r *http.Request) *appError {
 
 	writeResponse(w, api.ContentTypeJSON, encodedContent)
 	return nil
+}
+
+func handlePurgeEtagsInCache(w http.ResponseWriter, r *http.Request) *appError {
+	if catalogInstance.CacheReset() {
+		writeResponse(w, api.ContentTypeText, []byte("cache cleaned successfully"))
+		return nil
+	}
+	return appErrorInternal(nil, api.ErrMsgCacheCleaningFailed)
 }
 
 func handleCollections(w http.ResponseWriter, r *http.Request) *appError {
@@ -635,170 +641,192 @@ func linksItems(name string, urlBase string) []*api.Link {
 }
 
 func handleItem(w http.ResponseWriter, r *http.Request) *appError {
+
+	// Parameters
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
-
 	query := api.URLQuery(r.URL)
+
 	//--- extract request parameters
-	name := getRequestVar(routeVarCollectionID, r)
-	fid := getRequestVarStrip(routeVarFeatureID, r)
+	tableName := getRequestVar(routeVarFeatureID, r)
+	fid := getRequestVar(routeVarFeatureID, r)
 	reqParam, err := parseRequestParams(r)
 	if err != nil {
 		return appErrorBadRequest(err, err.Error())
 	}
 
-	// "If-Match" header
-	// TODO
-	// r.Header.Get("If-Match") ?
+	// Getting collection
+	tbl, err1 := catalogInstance.TableByName(tableName)
+	if err1 != nil {
+		return appErrorInternal(err1, api.ErrMsgCollectionAccess, tableName)
+	}
+	if tbl == nil {
+		return appErrorNotFound(err1, api.ErrMsgCollectionNotFound, tableName)
+	}
 
-	// "If-None-Match" header
-	ifNoneMatch := r.Header.Get("If-None-Match")
-	if ifNoneMatch != "" {
-		// TODO :
-		// - *
+	// Preconditional headers evaluation order according to RFC7232
+	// -> https://www.rfc-editor.org/rfc/rfc7232.html#section-2.3
+	// - If-Match
+	// - If-Unmodified-Since
+	// - If-None-Match
+	// - If-Modified-Since
+	// - If-Range
+	// - Range
 
-		eTagsList := strings.Split(ifNoneMatch, ",")
+	var eTagsList = make([]string, 1)
+	var checkPrecondition = false
+	var precondition = false
 
-		notModified, err := catalogInstance.CheckStrongEtags(eTagsList)
+	if r.Header.Get(headers.IfMatch) != "" {
+		checkPrecondition = true
+	} else if r.Header.Get(headers.IfNoneMatch) != "" {
+		checkPrecondition = true
+		ifNoneMatchValue := r.Header.Get(headers.IfNoneMatch)
+		if ifNoneMatchValue == "*" {
+			// "*" value prevents an unsafe request method (e.g., PUT) from inadvertently modifying an
+			// existing representation of the target resource when the client believes that the resource does
+			// not have a current representation : https://www.rfc-editor.org/rfc/rfc7232.html#section-3.2
+
+			// TODO : This section currently allows to retrieve the weak etag from database.
+			// But it will have to be deleted when we will be able to found easily the weak etag into the cache
+			// starting from the collection name and the feature id.
+			// This supposes a necessary modification of the cache structure
+			// ------------------------------------------------------------------------------------------------
+			reqParam, err := parseRequestParams(r)
+			if err != nil {
+				return appErrorBadRequest(err, err.Error())
+			}
+			param, errQuery := createQueryParams(&reqParam, tbl.Columns, tbl.Srid)
+			if errQuery == nil {
+				ctx := r.Context()
+				feature, err := catalogInstance.TableFeature(ctx, tableName, fid, param)
+				if err != nil {
+					return appErrorInternal(err, api.ErrMsgDataReadError, tableName)
+				}
+				if feature == nil {
+					return appErrorNotFound(nil, api.ErrMsgFeatureNotFound, fid)
+				}
+				weakEtag := "W/\"" + feature.WeakEtag + "\""
+				eTagsList[0] = weakEtag
+			} else {
+				return appErrorBadRequest(errQuery, api.ErrMsgInvalidQuery)
+			}
+			// ------------------------------------------------------------------------------------------------
+		} else {
+			eTagsList = strings.Split(ifNoneMatchValue, ",")
+		}
+
+		precondition, err = catalogInstance.CheckStrongEtags(eTagsList)
 		if err != nil {
-			return appErrorBadRequest(err, "Malformed etags are considered as not found in cache")
+			return appErrorBadRequest(err, "Malformed etags")
 		}
-		if notModified {
-			w.WriteHeader(http.StatusNotModified) // weak etag detected into the catalog cache
-			return nil
+
+	}
+
+	// Performing request according to its method
+	switch r.Method {
+	case http.MethodGet:
+		// GET
+		if checkPrecondition {
+			if !precondition {
+				w.WriteHeader(http.StatusNotModified) // weak etag detected into the cache
+				return nil
+			}
 		}
-	}
-
-	tbl, err1 := catalogInstance.TableByName(name)
-	if err1 != nil {
-		return appErrorInternal(err1, api.ErrMsgCollectionAccess, name)
-	}
-	if tbl == nil {
-		return appErrorNotFound(err1, api.ErrMsgCollectionNotFound, name)
-	}
-	param, errQuery := createQueryParams(&reqParam, tbl.Columns, tbl.Srid)
-
-	if errQuery == nil {
-		ctx := r.Context()
-
-		crs := reqParam.Crs // default "4326"
-
-		switch format {
-		case api.FormatJSON:
-			return writeItemJSON(ctx, w, name, fid, param, urlBase, crs)
-		case api.FormatHTML:
-			return writeItemHTML(w, tbl, name, fid, query, urlBase)
-		default:
-			return appErrorNotAcceptable(nil, api.ErrMsgNotSupportedFormat, format)
+		param, errQuery := createQueryParams(&reqParam, tbl.Columns, tbl.Srid)
+		if errQuery == nil {
+			ctx := r.Context()
+			crs := reqParam.Crs // default "4326"
+			switch format {
+			case api.FormatJSON:
+				return writeItemJSON(ctx, w, tableName, fid, param, urlBase, crs)
+			case api.FormatHTML:
+				return writeItemHTML(w, tbl, tableName, fid, query, urlBase)
+			default:
+				return appErrorNotAcceptable(nil, api.ErrMsgNotSupportedFormat, format)
+			}
+		} else {
+			return appErrorBadRequest(errQuery, api.ErrMsgInvalidQuery)
 		}
-	} else {
-		return appErrorBadRequest(errQuery, api.ErrMsgInvalidQuery)
-	}
-}
 
-func handlePartialUpdateItem(w http.ResponseWriter, r *http.Request) *appError {
-	// extract request parameters
-	name := getRequestVar(routeVarCollectionID, r)
-	fid := getRequestVarStrip(routeVarFeatureID, r)
+	case http.MethodPut:
+		// PUT
+		if checkPrecondition {
+			if !precondition {
+				w.WriteHeader(http.StatusPreconditionFailed) // weak etag detected into the cache
+				return nil
+			}
+		}
+		// extract JSON from request body
+		body, errBody := ioutil.ReadAll(r.Body)
+		if errBody != nil || len(body) == 0 {
+			return appErrorInternal(errBody, api.ErrMsgCollectionRequestBodyRead, tableName)
+		}
 
-	// check query parameters
-	queryValues := r.URL.Query()
-	paramValues := extractSingleArgs(queryValues)
-	if len(paramValues) != 0 {
-		return appErrorBadRequest(nil, api.ErrMsgNoParameters)
-	}
+		//--- check if body matches the schema
+		// schema for replace is the same as in create http://docs.ogc.org/DRAFTS/20-002.html#feature-geojson
+		createSchema, errGetSch := getCreateItemSchema(r.Context(), tbl)
+		if errGetSch != nil {
+			return appErrorInternal(errGetSch, errGetSch.Error())
+		}
+		var val interface{}
+		_ = json.Unmarshal(body, &val)
+		errValSch := createSchema.VisitJSON(val)
+		if errValSch != nil {
+			return appErrorBadRequest(errValSch, api.ErrMsgReplaceFeatureNotConform)
+		}
 
-	// check that collection exists
-	tbl, err1 := catalogInstance.TableByName(name)
-	if err1 != nil {
-		return appErrorInternal(err1, api.ErrMsgCollectionAccess, name)
-	}
-	if tbl == nil {
-		return appErrorNotFound(err1, api.ErrMsgCollectionNotFound, name)
-	}
+		// perform replace in database
+		err2 := catalogInstance.ReplaceTableFeature(r.Context(), tableName, fid, body)
+		if err2 != nil {
+			return appErrorInternal(err2, api.ErrMsgReplaceFeature, tableName)
+		}
 
-	// extract JSON from request body
-	body, errBody := ioutil.ReadAll(r.Body)
-	if errBody != nil || len(body) == 0 {
-		return appErrorInternal(errBody, api.ErrMsgCollectionRequestBodyRead, name)
-	}
+		w.WriteHeader(http.StatusNoContent)
+		return nil
 
-	// check schema
-	updateSchema, errGetSch := getUpdateItemSchema(r.Context(), tbl)
-	if errGetSch != nil {
-		return appErrorInternal(errGetSch, errGetSch.Error())
-	}
-	var val map[string]interface{}
-	_ = json.Unmarshal(body, &val)
-	errValSch := updateSchema.VisitJSON(val)
-	if errValSch != nil {
-		return appErrorBadRequest(errValSch, api.ErrMsgPartialUpdateFeatureNotConform, name)
-	}
+	case http.MethodPatch:
+		// PATCH
+		if checkPrecondition {
+			if !precondition {
+				w.WriteHeader(http.StatusPreconditionFailed) // weak etag detected into the cache
+				return nil
+			}
+		}
 
-	check, errChck := tbl.CheckTableFields(val)
-	if !check && errChck != nil {
-		return appErrorBadRequest(errChck, "validation error")
-	}
+		body, errBody := ioutil.ReadAll(r.Body) // extract JSON from request body
+		if errBody != nil || len(body) == 0 {
+			return appErrorInternal(errBody, api.ErrMsgCollectionRequestBodyRead, tableName)
+		}
+		// check schema
+		updateSchema, errGetSch := getUpdateItemSchema(r.Context(), tbl)
+		if errGetSch != nil {
+			return appErrorInternal(errGetSch, errGetSch.Error())
+		}
+		var val map[string]interface{}
+		_ = json.Unmarshal(body, &val)
+		errValSch := updateSchema.VisitJSON(val)
+		if errValSch != nil {
+			return appErrorBadRequest(errValSch, api.ErrMsgPartialUpdateFeatureNotConform, tableName)
+		}
 
-	// perform update in database
-	err := catalogInstance.PartialUpdateTableFeature(r.Context(), name, fid, body)
-	if err != nil {
-		return appErrorInternal(err, api.ErrMsgPartialUpdateFeature, name)
-	}
+		check, errChck := tbl.CheckTableFields(val)
+		if !check && errChck != nil {
+			return appErrorBadRequest(errChck, "validation error")
+		}
 
-	w.WriteHeader(http.StatusNoContent)
-	return nil
-}
+		// perform update in database
+		errUpdate := catalogInstance.PartialUpdateTableFeature(r.Context(), tableName, fid, body)
+		if errUpdate != nil {
+			return appErrorInternal(errUpdate, api.ErrMsgPartialUpdateFeature, tableName)
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return nil
 
-func handleReplaceItem(w http.ResponseWriter, r *http.Request) *appError {
-
-	// extract request parameters
-	name := getRequestVar(routeVarCollectionID, r)
-	fid := getRequestVarStrip(routeVarFeatureID, r)
-
-	// check query parameters
-	queryValues := r.URL.Query()
-	paramValues := extractSingleArgs(queryValues)
-	if len(paramValues) != 0 {
-		return appErrorBadRequest(nil, api.ErrMsgNoParameters)
-	}
-
-	// check that collection exists
-	tbl, err1 := catalogInstance.TableByName(name)
-	if err1 != nil {
-		return appErrorInternal(err1, api.ErrMsgCollectionAccess, name)
-	}
-	if tbl == nil {
-		return appErrorNotFound(err1, api.ErrMsgCollectionNotFound, name)
+	default:
+		return nil
 	}
 
-	// extract JSON from request body
-	body, errBody := ioutil.ReadAll(r.Body)
-	if errBody != nil || len(body) == 0 {
-		return appErrorInternal(errBody, api.ErrMsgCollectionRequestBodyRead, name)
-	}
-
-	//--- check if body matches the schema
-	// schema for replace is the same as in create http://docs.ogc.org/DRAFTS/20-002.html#feature-geojson
-	createSchema, errGetSch := getCreateItemSchema(r.Context(), tbl)
-	if errGetSch != nil {
-		return appErrorInternal(errGetSch, errGetSch.Error())
-	}
-	var val interface{}
-	_ = json.Unmarshal(body, &val)
-	errValSch := createSchema.VisitJSON(val)
-	if errValSch != nil {
-		return appErrorBadRequest(errValSch, api.ErrMsgReplaceFeatureNotConform)
-	}
-
-	// perform replace in database
-	err2 := catalogInstance.ReplaceTableFeature(r.Context(), name, fid, body)
-	if err2 != nil {
-		return appErrorInternal(err2, api.ErrMsgReplaceFeature, name)
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-	return nil
 }
 
 func writeItemHTML(w http.ResponseWriter, tbl *api.Table, name string, fid string, query string, urlBase string) *appError {
@@ -844,6 +872,17 @@ func writeItemJSON(ctx context.Context, w http.ResponseWriter, tableName string,
 	encodedStrongEtag := base64.StdEncoding.EncodeToString([]byte(strongEtag))
 	w.Header().Set("Etag", encodedStrongEtag)
 	w.Header().Set("Last-Modified", feature.LastModifiedDate)
+
+	// Check the etag presence into the cache, and add it if necessary
+	weakEtagToCheck := "W/\"" + feature.WeakEtag + "\""
+	notPresent, err := catalogInstance.CheckStrongEtags([]string{weakEtagToCheck})
+	if err != nil {
+		return appErrorBadRequest(err, api.ErrMsgMalformedEtag, weakEtagToCheck)
+	}
+	if notPresent {
+		//nolint:errcheck
+		catalogInstance.AddEtagToCache(feature.WeakEtag, map[string]interface{}{"last-modified": feature.LastModifiedDate})
+	}
 
 	writeResponse(w, api.ContentTypeGeoJSON, encodedContent)
 	return nil

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -317,7 +317,6 @@ func handleCollection(w http.ResponseWriter, r *http.Request) *appError {
 }
 
 func handleCollectionSchemas(w http.ResponseWriter, r *http.Request) *appError {
-	// TODO: determine content from request header?
 	format := api.RequestedFormat(r)
 
 	//--- extract request parameters
@@ -446,7 +445,6 @@ func handleDeleteCollectionItem(w http.ResponseWriter, r *http.Request) *appErro
 
 func handleCollectionItems(w http.ResponseWriter, r *http.Request) *appError {
 	// "/collections/{id}/items"
-	// TODO: determine content from request header?
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
 	query := api.URLQuery(r.URL)
@@ -719,25 +717,35 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 		precondition = !present
 	}
 
+	// check precondition
+	if checkPrecondition && !precondition {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotModified) // weak etag detected into the cache
+
+		default:
+			w.WriteHeader(http.StatusPreconditionFailed) // weak etag detected into the cache
+
+		}
+
+		return nil
+	}
+
 	// Performing request according to its method
 	switch r.Method {
 	case http.MethodGet:
 		// GET
-		if checkPrecondition {
-			if !precondition {
-				w.WriteHeader(http.StatusNotModified) // weak etag detected into the cache
-				return nil
-			}
-		}
 		param, errQuery := createQueryParams(&reqParam, tbl.Columns, tbl.Srid)
 		if errQuery == nil {
-			ctx := r.Context()
 			crs := reqParam.Crs // default "4326"
+
 			switch format {
 			case api.FormatJSON:
-				return writeItemJSON(ctx, w, tableName, fid, param, urlBase, crs)
+				return writeItemJSON(r.Context(), w, tableName, fid, param, urlBase, crs)
+
 			case api.FormatHTML:
 				return writeItemHTML(w, tbl, tableName, fid, query, urlBase)
+
 			default:
 				return appErrorNotAcceptable(nil, api.ErrMsgNotSupportedFormat, format)
 			}
@@ -747,12 +755,6 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 
 	case http.MethodPut:
 		// PUT
-		if checkPrecondition {
-			if !precondition {
-				w.WriteHeader(http.StatusPreconditionFailed) // weak etag detected into the cache
-				return nil
-			}
-		}
 		// extract JSON from request body
 		body, errBody := ioutil.ReadAll(r.Body)
 		if errBody != nil || len(body) == 0 {
@@ -783,14 +785,8 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 
 	case http.MethodPatch:
 		// PATCH
-		if checkPrecondition {
-			if !precondition {
-				w.WriteHeader(http.StatusPreconditionFailed) // weak etag detected into the cache
-				return nil
-			}
-		}
-
-		body, errBody := ioutil.ReadAll(r.Body) // extract JSON from request body
+		// extract JSON from request body
+		body, errBody := ioutil.ReadAll(r.Body)
 		if errBody != nil || len(body) == 0 {
 			return appErrorInternal(errBody, api.ErrMsgCollectionRequestBodyRead, tableName)
 		}
@@ -870,27 +866,11 @@ func writeItemJSON(ctx context.Context, w http.ResponseWriter, tableName string,
 	w.Header().Set("Etag", encodedStrongEtag)
 	w.Header().Set("Last-Modified", strongEtag.WeakEtagData.LastModified)
 
-	// TODO should not be here! What if the output format is html?
-	// Check the etag presence into the cache, and add it if necessary
-	weakEtagStr := strongEtag.WeakEtagData.String()
-	present, err := data.IsOneEtagInCache(catalogInstance.GetCache(), []string{weakEtagStr})
-	if err != nil {
-		return appErrorBadRequest(err, api.ErrMsgMalformedEtag, weakEtagStr)
-	}
-	if !present {
-		// ===== DOUBLE ADD!!
-		//nolint:errcheck
-		catalogInstance.GetCache().AddWeakEtag(strongEtag.WeakEtagData.CacheKey(), strongEtag.WeakEtagData)
-		//nolint:errcheck
-		catalogInstance.GetCache().AddWeakEtag(strongEtag.WeakEtagData.AlternateCacheKey(), strongEtag.WeakEtagData)
-	}
-
 	writeResponse(w, api.ContentTypeGeoJSON, encodedContent)
 	return nil
 }
 
 func handleConformance(w http.ResponseWriter, r *http.Request) *appError {
-	// TODO: determine content from request header?
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
 
@@ -909,7 +889,6 @@ func handleConformance(w http.ResponseWriter, r *http.Request) *appError {
 }
 
 func handleAPI(w http.ResponseWriter, r *http.Request) *appError {
-	// TODO: determine content from request header?
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
 
@@ -1053,7 +1032,6 @@ func handleFunction(w http.ResponseWriter, r *http.Request) *appError {
 }
 
 func handleFunctionItems(w http.ResponseWriter, r *http.Request) *appError {
-	// TODO: determine content from request header?
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
 

--- a/internal/service/mock_test/runner_mock_test.go
+++ b/internal/service/mock_test/runner_mock_test.go
@@ -324,7 +324,7 @@ func checkRouteWithAcceptHeader(t *testing.T, url string, acceptValue string, ex
 	contentType := resp.Result().Header["Content-Type"][0]
 
 	if expectedFormat != "" {
-		util.Assert(t, contentType == expectedFormat, fmt.Sprintf("Content-Type: %s", contentType))
+		util.Equals(t, expectedFormat, contentType, fmt.Sprintf("Content-Type: %s", contentType))
 	} else {
 		util.Assert(t, strings.Contains(acceptValue, contentType), fmt.Sprintf("Content-Type: %s", contentType))
 	}

--- a/internal/util/test_db.go
+++ b/internal/util/test_db.go
@@ -169,8 +169,8 @@ func InsertComplexDataset(db *pgxpool.Pool, schema string) {
 	_, errExec := db.Exec(ctx, fmt.Sprintf(`
 		DROP TABLE IF EXISTS %s.mock_multi CASCADE;
 		CREATE TABLE IF NOT EXISTS %s.mock_multi (
-			id SERIAL PRIMARY KEY,
 			geometry public.geometry(Point, 4326) NOT NULL,
+			fid SERIAL PRIMARY KEY,
 			prop_t text NOT NULL,
 			prop_i int NOT NULL,
 			prop_l bigint NOT NULL,

--- a/internal/util/test_http.go
+++ b/internal/util/test_http.go
@@ -124,11 +124,11 @@ func (hTest *HttpTesting) DoRequestMethodStatus(t *testing.T, method string, url
 		if bodyMsg != "" {
 			Equals(t,
 				statusExpected, status,
-				fmt.Errorf("handler returned wrong status code.\n\tCaused by: %v", bodyMsg).Error())
+				fmt.Errorf("handler returned wrong status code for url '%v'.\n\tCaused by: %v", url, bodyMsg).Error())
 		} else {
 			Equals(t,
 				statusExpected, status,
-				"handler returned wrong status code.")
+				fmt.Errorf("handler returned wrong status code for url '%v'.", url).Error())
 		}
 	}
 	return rr


### PR DESCRIPTION
Precondition headers management factorized (including if-none-match for instance).

For information:
- a route `/etags/purge` has been added to allow to purge the cache content through the REST service. (For test purpose for instance)
- After refactoring, the handleItem() function computes now the GET/PUT/PATCH requests on a feature :
  `/collections/{id}/items/{fid}`
  `/collections/{id}/items/{fid}.{fmt}`


