### PR TITLE
Feature/add special schema support

### DIFF
--- a/internal/data/listener.go
+++ b/internal/data/listener.go
@@ -46,7 +46,7 @@ type listenerDB struct {
 // event on the databases included in pg_featureserv. It is populated using the return value of
 // the pl/pgSQL procedure named `sqlNotifyFunction` defined in db_sql.go
 type eventNotification struct {
-	Id       string
+	Id       string                 // Identifier of table in form schema.table_name with quoted values if needed
 	Schema   string                 // schema of the table triggering the event
 	Table    string                 // name of the table triggering the event
 	Action   string                 // action triggering the event (INSERT, UPDATE or DELETE)
@@ -57,7 +57,7 @@ type eventNotification struct {
 
 // toString for eventNotification
 func (e eventNotification) String() string {
-	return fmt.Sprintf("eventNotification[table: '%v.%v', action: '%v', xmin: %v/%v, data: %v]", e.Schema, e.Table, e.Action, e.Old_xmin, e.New_xmin, e.Data)
+	return fmt.Sprintf("eventNotification[Id: %v, table: '%v.%v', action: '%v', xmin: %v/%v, data: %v]", e.Id, e.Schema, e.Table, e.Action, e.Old_xmin, e.New_xmin, e.Data)
 }
 
 // creates new db listener

--- a/internal/service/db_test/handler_db_update_test.go
+++ b/internal/service/db_test/handler_db_update_test.go
@@ -201,8 +201,8 @@ func (t *DbTests) TesUpdateComplexFeatureDbWrongCrs() {
 	})
 }
 
-func (t *DbTests) TestUpdateComplexSchemaName() {
-	t.Test.Run("TestUpdateComplexSchemaName", func(t *testing.T) {
+func (t *DbTests) TestSpecialSchemaTableColumnName() {
+	t.Test.Run("TestSpecialSchemaTableColumnName", func(t *testing.T) {
 		path := url.QueryEscape(fmt.Sprintf(`/collections/%s.%s/items/3`, util.SpecialSchemaStr, util.SpecialTableStr))
 		var header = make(http.Header)
 		header.Add("Content-Type", api.ContentTypeSchemaPatchJSON)

--- a/internal/service/db_test/handler_db_update_test.go
+++ b/internal/service/db_test/handler_db_update_test.go
@@ -233,5 +233,8 @@ func (t *DbTests) TestUpdateComplexSchemaName() {
 		coordinate := geom["coordinates"].([]interface{})
 		util.Equals(t, -120, int(coordinate[0].(float64)), "feature latitude")
 		util.Equals(t, 40, int(coordinate[1].(float64)), "feature longitude")
+
+		props := jsonData["properties"].(map[string]interface{})
+		util.Equals(t, nil, props[util.SpecialColumnStr], fmt.Sprintf("feature value %s", util.SpecialColumnStr))
 	})
 }

--- a/internal/service/db_test/handler_db_update_test.go
+++ b/internal/service/db_test/handler_db_update_test.go
@@ -203,7 +203,7 @@ func (t *DbTests) TesUpdateComplexFeatureDbWrongCrs() {
 
 func (t *DbTests) TestUpdateComplexSchemaName() {
 	t.Test.Run("TestUpdateComplexSchemaName", func(t *testing.T) {
-		path := url.QueryEscape(fmt.Sprintf(`/collections/%s.mock_ssimple/items/3`, util.SpecialSchemaStr))
+		path := url.QueryEscape(fmt.Sprintf(`/collections/%s.%s/items/3`, util.SpecialSchemaStr, util.SpecialTableStr))
 		var header = make(http.Header)
 		header.Add("Content-Type", api.ContentTypeSchemaPatchJSON)
 
@@ -221,7 +221,7 @@ func (t *DbTests) TestUpdateComplexSchemaName() {
 		_ = hTest.DoRequestMethodStatus(t, "PATCH", path, []byte(jsonStr), header, http.StatusNoContent)
 
 		// check if it can be read
-		feature := checkItem(t, fmt.Sprintf(`%s.mock_ssimple`, util.SpecialSchemaStr), 3)
+		feature := checkItem(t, fmt.Sprintf(`%s.%s`, util.SpecialSchemaStr, util.SpecialTableStr), 3)
 		var jsonData map[string]interface{}
 		errUnMarsh := json.Unmarshal(feature, &jsonData)
 		util.Assert(t, errUnMarsh == nil, fmt.Sprintf("%v", errUnMarsh))

--- a/internal/service/db_test/runner_db_test.go
+++ b/internal/service/db_test/runner_db_test.go
@@ -164,10 +164,10 @@ func TestRunnerHandlerDb(t *testing.T) {
 		afterEachRun()
 	})
 
-	t.Run("COMPLEX_SCHEMA", func(t *testing.T) {
+	t.Run("SPECIAL_SCHEMA_TABLE_COLUMN", func(t *testing.T) {
 		beforeEachRun()
 		test := DbTests{Test: t}
-		test.TestUpdateComplexSchemaName()
+		test.TestSpecialSchemaTableColumnName()
 		afterEachRun()
 	})
 

--- a/internal/service/db_test/runner_db_test.go
+++ b/internal/service/db_test/runner_db_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strconv"
 	"testing"
@@ -163,6 +164,13 @@ func TestRunnerHandlerDb(t *testing.T) {
 		afterEachRun()
 	})
 
+	t.Run("COMPLEX_SCHEMA", func(t *testing.T) {
+		beforeEachRun()
+		test := DbTests{Test: t}
+		test.TestUpdateComplexSchemaName()
+		afterEachRun()
+	})
+
 	// after tests cleaning
 	afterRun()
 }
@@ -198,7 +206,7 @@ func afterEachRun() {
 // Check if item is available and is not empty
 // (copy from service/handler_test.go)
 func checkItem(t *testing.T, tableName string, id int) []byte {
-	path := fmt.Sprintf("/collections/%v/items/%d", tableName, id)
+	path := fmt.Sprintf("/collections/%v/items/%d", url.QueryEscape(tableName), id)
 	resp := hTest.DoRequest(t, path)
 	body, _ := ioutil.ReadAll(resp.Body)
 

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -170,12 +170,12 @@ func InsertSuperSimpleDataset(db *pgxpool.Pool, schema string, tablename string)
 			geometry public.geometry(Point, 4326) NOT NULL,
 			%s text
 		);
-		CREATE INDEX %s_geometry_idx ON %s USING GIST (geometry);
+		CREATE INDEX geometry_idx ON %s USING GIST (geometry);
 	`)
 	for s := range tablesAndExtents {
 
 		tableNameWithSchema := fmt.Sprintf("%s.%s", schema, s)
-		createStatement := fmt.Sprintf(string(createBytes), tableNameWithSchema, tableNameWithSchema, SpecialColumnStr)
+		createStatement := fmt.Sprintf(string(createBytes), tableNameWithSchema, tableNameWithSchema, SpecialColumnStr, tableNameWithSchema)
 
 		_, errExec := db.Exec(ctx, createStatement)
 		if errExec != nil {

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -33,6 +33,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const SpecialSchemaStr = `"😀.$^{schema}"`
+
 func CreateTestDb() *pgxpool.Pool {
 	dbURL := os.Getenv(conf.AppConfig.EnvDBURL)
 	if dbURL == "" {
@@ -58,9 +60,11 @@ func CreateTestDb() *pgxpool.Pool {
 	log.Debugf("Connected as %s to %s @ %s", dbUser, dbName, dbHost)
 
 	CreateSchema(db, "complex")
+	CreateSchema(db, SpecialSchemaStr)
 	InsertSimpleDataset(db, "public")
 	InsertSuperSimpleDataset(db, "public")
 	InsertComplexDataset(db, "complex")
+	InsertSuperSimpleDataset(db, SpecialSchemaStr)
 
 	log.Debugf("Sample data injected")
 
@@ -287,7 +291,7 @@ func InsertComplexDataset(db *pgxpool.Pool, schema string) {
 func CloseTestDb(db *pgxpool.Pool) {
 	log.Debugf("Sample dbs will be cleared...")
 	var sql string
-	for _, t := range []string{"public.mock_a", "public.mock_b", "public.mock_c", "complex.mock_multi"} {
+	for _, t := range []string{"public.mock_a", "public.mock_b", "public.mock_c", "complex.mock_multi", fmt.Sprintf(`%s.mock_ssimple`, SpecialSchemaStr)} {
 		sql = fmt.Sprintf("%s DROP TABLE IF EXISTS %s CASCADE;", sql, t)
 	}
 	_, errExec := db.Exec(context.Background(), sql)

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -292,7 +292,7 @@ func InsertComplexDataset(db *pgxpool.Pool, schema string) {
 func CloseTestDb(db *pgxpool.Pool) {
 	log.Debugf("Sample dbs will be cleared...")
 	var sql string
-	for _, t := range []string{"public.mock_a", "public.mock_b", "public.mock_c", "complex.mock_multi", fmt.Sprintf(`%s.mock_ssimple`, SpecialSchemaStr)} {
+	for _, t := range []string{"public.mock_a", "public.mock_b", "public.mock_c", "complex.mock_multi", fmt.Sprintf(`%s.%s`, SpecialSchemaStr, SpecialTableStr)} {
 		sql = fmt.Sprintf("%s DROP TABLE IF EXISTS %s CASCADE;", sql, t)
 	}
 	_, errExec := db.Exec(context.Background(), sql)

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -33,9 +33,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const SpecialSchemaStr = `"😀.$^{schema}"`
-const SpecialTableStr = `"😀.$^{table}"`
-const SpecialColumnStr = `"😀.$^{column}"`
+const SpecialSchemaStr = `"😀.$^{schema}.👿.😱"`
+const SpecialTableStr = `"😀.$^{table}.👿.😱"`
+const SpecialColumnStr = `"😀.$^{column}.👿.😱"`
 
 func CreateTestDb() *pgxpool.Pool {
 	dbURL := os.Getenv(conf.AppConfig.EnvDBURL)

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -35,6 +35,7 @@ import (
 
 const SpecialSchemaStr = `"😀.$^{schema}"`
 const SpecialTableStr = `"😀.$^{table}"`
+const SpecialColumnStr = `"😀.$^{column}"`
 
 func CreateTestDb() *pgxpool.Pool {
 	dbURL := os.Getenv(conf.AppConfig.EnvDBURL)
@@ -166,14 +167,15 @@ func InsertSuperSimpleDataset(db *pgxpool.Pool, schema string, tablename string)
 		DROP TABLE IF EXISTS %s CASCADE;
 		CREATE TABLE IF NOT EXISTS %s (
 			id SERIAL PRIMARY KEY,
-			geometry public.geometry(Point, 4326) NOT NULL
+			geometry public.geometry(Point, 4326) NOT NULL,
+			%s text
 		);
 		CREATE INDEX %s_geometry_idx ON %s USING GIST (geometry);
 	`)
 	for s := range tablesAndExtents {
 
 		tableNameWithSchema := fmt.Sprintf("%s.%s", schema, s)
-		createStatement := fmt.Sprintf(string(createBytes), tableNameWithSchema, tableNameWithSchema, s, tableNameWithSchema)
+		createStatement := fmt.Sprintf(string(createBytes), tableNameWithSchema, tableNameWithSchema, SpecialColumnStr)
 
 		_, errExec := db.Exec(ctx, createStatement)
 		if errExec != nil {

--- a/internal/utiltest/test_db.go
+++ b/internal/utiltest/test_db.go
@@ -34,6 +34,7 @@ import (
 )
 
 const SpecialSchemaStr = `"😀.$^{schema}"`
+const SpecialTableStr = `"😀.$^{table}"`
 
 func CreateTestDb() *pgxpool.Pool {
 	dbURL := os.Getenv(conf.AppConfig.EnvDBURL)
@@ -62,9 +63,9 @@ func CreateTestDb() *pgxpool.Pool {
 	CreateSchema(db, "complex")
 	CreateSchema(db, SpecialSchemaStr)
 	InsertSimpleDataset(db, "public")
-	InsertSuperSimpleDataset(db, "public")
+	InsertSuperSimpleDataset(db, "public", "mock_ssimple")
 	InsertComplexDataset(db, "complex")
-	InsertSuperSimpleDataset(db, SpecialSchemaStr)
+	InsertSuperSimpleDataset(db, SpecialSchemaStr, SpecialTableStr)
 
 	log.Debugf("Sample data injected")
 
@@ -148,7 +149,7 @@ func InsertSimpleDataset(db *pgxpool.Pool, schema string) {
 	}
 }
 
-func InsertSuperSimpleDataset(db *pgxpool.Pool, schema string) {
+func InsertSuperSimpleDataset(db *pgxpool.Pool, schema string, tablename string) {
 	ctx := context.Background()
 	// collections tables
 	// tables := []string{"mock_a", "mock_b", "mock_c"}
@@ -158,7 +159,7 @@ func InsertSuperSimpleDataset(db *pgxpool.Pool, schema string) {
 		ny     int
 	}
 	tablesAndExtents := map[string]tableContent{
-		"mock_ssimple": {api.Extent{Minx: -120, Miny: 40, Maxx: -74, Maxy: 50}, 3, 3},
+		tablename: {api.Extent{Minx: -120, Miny: 40, Maxx: -74, Maxy: 50}, 3, 3},
 	}
 
 	createBytes := []byte(`


### PR DESCRIPTION
ref #55 

- update definition of table and schema name to use SQL formatting to get quoted values if needed (use of %I format option) (`internal/data/db_sql.go`)

- update return of notification for listener:
    - add use of %I SQL formatting to get quoted value for schema and table name
    - update `eventNotification` struct to get formatted Id

- fix creation and drop of trigger in listener to avoid issue with special schema and table name (`internal/data/listener.go`)

- add tests with special schema / table / column names